### PR TITLE
[Bug] Add Modules to Lazy Load List

### DIFF
--- a/flytekit/plugins/__init__.py
+++ b/flytekit/plugins/__init__.py
@@ -6,7 +6,6 @@ pyspark = _lazy_loader.LazyLoadPlugin(
     ["pyspark>=2.4.0,<3.0.0"],
     [
         "pyspark",
-        "flyteidl.plugins.spark_pb2",
     ]
 )
 

--- a/flytekit/plugins/__init__.py
+++ b/flytekit/plugins/__init__.py
@@ -5,7 +5,8 @@ pyspark = _lazy_loader.LazyLoadPlugin(
     "spark",
     ["pyspark>=2.4.0,<3.0.0"],
     [
-        "pyspark"
+        "pyspark",
+        "flyteidl.plugins.spark_pb2",
     ]
 )
 
@@ -15,6 +16,7 @@ k8s = _lazy_loader.LazyLoadPlugin(
     [
         "k8s.io.api.core.v1.generated_pb2",
         "k8s.io.apimachinery.pkg.api.resource.generated_pb2",
+        "flyteidl.plugins.sidecar_pb2",
     ]
 )
 


### PR DESCRIPTION
There is a transient dependency on `k8s-proto` through `flyteidl.plugins`.  Since we only want to install k8s-proto when it is needed, we need to add another module to the lazy load list.