### PR TITLE
[Bug] Error message isn't properly raised because abstract class is accessed during rendering of the error

### DIFF
--- a/flytekit/common/types/containers.py
+++ b/flytekit/common/types/containers.py
@@ -55,16 +55,15 @@ class TypedListImpl(_six.with_metaclass(TypedCollectionType, ListImpl)):
         :param Text string_value:
         :rtype: ListImpl<T>
         """
-
         try:
             items = _json.loads(string_value)
         except ValueError:
             raise _user_exceptions.FlyteTypeException(
-                _six.text_type, TypedListImpl, additional_msg='String not parseable to json {}'.format(string_value))
+                _six.text_type, cls, additional_msg='String not parseable to json {}'.format(string_value))
 
         if type(items) != list:
             raise _user_exceptions.FlyteTypeException(
-                _six.text_type, TypedListImpl, additional_msg='String is not a list {}'.format(string_value))
+                _six.text_type, cls, additional_msg='String is not a list {}'.format(string_value))
 
         # Instead of recursively calling from_string(), we're changing to from_python_std() instead because json
         # loading naturally interprets all layers, not just the outer layer.
@@ -130,7 +129,7 @@ class TypedListImpl(_six.with_metaclass(TypedCollectionType, ListImpl)):
         """
         :rtype: list[T]
         """
-        return [self._sub_type.from_flyte_idl(l.to_flyte_idl()).to_python_std() for l in self.collection.literals]
+        return [type(self).sub_type.from_flyte_idl(l.to_flyte_idl()).to_python_std() for l in self.collection.literals]
 
     def short_string(self):
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ max-complexity=16
 [tool:pytest]
 norecursedirs = common workflows spark
 log_cli = true
-log_cli_level = 0
+log_cli_level = 100
 
 [pep8]
 max-line-length = 120

--- a/tests/flytekit/unit/common_tests/types/test_containers.py
+++ b/tests/flytekit/unit/common_tests/types/test_containers.py
@@ -45,6 +45,9 @@ def test_list():
     with pytest.raises(_user_exceptions.FlyteTypeException):
         list_type.from_string('[1, 2, 3, []]')
 
+    with pytest.raises(_user_exceptions.FlyteTypeException):
+        list_type.from_string('\'["not json"]\'')
+
 
 def test_string_list():
     list_type = containers.List(primitives.String)

--- a/tests/flytekit/unit/common_tests/types/test_containers.py
+++ b/tests/flytekit/unit/common_tests/types/test_containers.py
@@ -46,7 +46,10 @@ def test_list():
         list_type.from_string('[1, 2, 3, []]')
 
     with pytest.raises(_user_exceptions.FlyteTypeException):
-        list_type.from_string('\'["not json"]\'')
+        list_type.from_string('\'["not list json"]\'')
+
+    with pytest.raises(_user_exceptions.FlyteTypeException):
+        list_type.from_string('["unclosed","list"')
 
 
 def test_string_list():


### PR DESCRIPTION
The exception fails to raise properly because an abstract class is used as the type comparison. This fixes that and adds two tests.