### PR TITLE
Implement client-side behavior for active launch plans

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 import flytekit.plugins
 
-__version__ = '0.1.7'
+__version__ = '0.1.8'

--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -262,6 +262,16 @@ class RawSynchronousFlyteClient(object):
         return self._stub.GetLaunchPlan(object_get_request)
 
     @_handle_rpc_error
+    def get_active_launch_plan(self, active_launch_plan_request):
+        """
+        Retrieves a launch plan entity.
+
+        :param flyteidl.admin.common_pb2.ActiveLaunchPlanRequest active_launch_plan_request:
+        :rtype: flyteidl.admin.launch_plan_pb2.LaunchPlan
+        """
+        return self._stub.GetActiveLaunchPlan(active_launch_plan_request)
+
+    @_handle_rpc_error
     def update_launch_plan(self, update_request):
         """
         Allows updates to a launch plan at a given identifier.  Currently, a launch plan may only have it's state
@@ -291,6 +301,16 @@ class RawSynchronousFlyteClient(object):
         :rtype: flyteidl.admin.launch_plan_pb2.LaunchPlanList
         """
         return self._stub.ListLaunchPlans(resource_list_request)
+
+    @_handle_rpc_error
+    def list_active_launch_plans_paginated(self, active_launch_plan_list_request):
+        """
+        Lists Active Launch Plans for a given (project, domain)
+
+        :param: flyteidl.admin.common_pb2.ActiveLaunchPlanListRequest active_launch_plan_list_request:
+        :rtype: flyteidl.admin.launch_plan_pb2.LaunchPlanList
+        """
+        return self._stub.ListActiveLaunchPlans(active_launch_plan_list_request)
 
     ####################################################################################################################
     #

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -778,17 +778,11 @@ def list_active_launch_plans(project, domain, host, insecure, token, limit, show
     client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
 
     while True:
-        active_lps, next_token = client.list_launch_plans_paginated(
-            _common_models.NamedEntityIdentifier(
-                project,
-                domain
-            ),
+        active_lps, next_token = client.list_active_launch_plans_paginated(
+            project,
+            domain,
             limit=limit,
             token=token,
-            filters=[
-                _filters.Equal('state', '1'),
-                _filters.ValueIn('schedule_type', ['CRON', 'RATE'])
-            ],
             sort_by=_admin_common.Sort.from_python_std(sort_by) if sort_by else None
         )
 

--- a/flytekit/clis/sdk_in_container/launch_plan.py
+++ b/flytekit/clis/sdk_in_container/launch_plan.py
@@ -191,7 +191,7 @@ def activate_all_schedules(ctx, version=None):
 @click.option('-v', '--version', type=str, help='Version to register tasks with. This is normally parsed from the'
                                                 'image, but you can override here.')
 @click.pass_context
-def activate_all_schedules(ctx, version=None):
+def activate_all(ctx, version=None):
     """
     This command will activate all found launch plans at the given version.  If there are existing
     active launch plans that collide on project, domain, and name, but differ on version, those will be

--- a/flytekit/common/launch_plan.py
+++ b/flytekit/common/launch_plan.py
@@ -58,7 +58,8 @@ class SdkLaunchPlan(
         :param Text project:
         :param Text domain:
         :param Text name:
-        :param Text version:
+        :param Text version: [Optional] If not set, the SDK will fetch the active launch plan for the given project,
+            domain, and name.
         :rtype: SdkLaunchPlan
         """
         version = version or _internal_config.VERSION.get()
@@ -67,7 +68,7 @@ class SdkLaunchPlan(
         )
         lp = _engine_loader.get_engine().fetch_launch_plan(launch_plan_id)
         sdk_lp = cls.promote_from_model(lp.spec)
-        sdk_lp._id = launch_plan_id
+        sdk_lp._id = lp.id
         return sdk_lp
 
     @_exception_scopes.system_entry_point

--- a/flytekit/engines/flyte/engine.py
+++ b/flytekit/engines/flyte/engine.py
@@ -18,7 +18,7 @@ from flytekit.engines import common as _common_engine
 from flytekit.interfaces.data import data_proxy as _data_proxy
 from flytekit.interfaces.stats.taggable import get_stats as _get_stats
 from flytekit.models import task as _task_models, execution as _execution_models, \
-    literals as _literals
+    literals as _literals, common as _common_models
 from flytekit.models.admin import workflow as _workflow_model
 from flytekit.models.core import errors as _error_models
 from flytekit.models.core.identifier import WorkflowExecutionIdentifier
@@ -114,10 +114,21 @@ class FlyteEngineFactory(_common_engine.BaseExecutionEngineFactory):
             type of kind LaunchPlan.
         :rtype: flytekit.models.launch_plan.LaunchPlan
         """
-        return _FlyteClientManager(
-            _platform_config.URL.get(),
-            insecure=_platform_config.INSECURE.get()
-        ).client.get_launch_plan(launch_plan_id)
+        if launch_plan_id.version:
+            return _FlyteClientManager(
+                _platform_config.URL.get(),
+                insecure=_platform_config.INSECURE.get()
+            ).client.get_launch_plan(launch_plan_id)
+        else:
+            named_entity_id = _common_models.NamedEntityIdentifier(
+                launch_plan_id.project,
+                launch_plan_id.domain,
+                launch_plan_id.name
+            )
+            return _FlyteClientManager(
+                _platform_config.URL.get(),
+                insecure=_platform_config.INSECURE.get()
+            ).client.get_active_launch_plan(named_entity_id)
 
     def fetch_workflow(self, workflow_id):
         """

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     install_requires=[
         "sloth-import>=0.2.3,<1.0.0",
         "flyteidl>=0.14.0,<1.0.0",
-        "click>=6.6,<7.0",
+        "click>=7.0,<8.0",
         "configparser>=3.0.0,<4.0.0",
         "croniter>=0.3.20,<4.0.0",
         "deprecation>=2.0,<3.0",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     ],
     install_requires=[
         "sloth-import>=0.2.3,<1.0.0",
-        "flyteidl>=0.11.6,<1.0.0",
+        "flyteidl>=0.14.0,<1.0.0",
         "click>=6.6,<7.0",
         "configparser>=3.0.0,<4.0.0",
         "croniter>=0.3.20,<4.0.0",

--- a/tests/flytekit/unit/engines/flyte/test_engine.py
+++ b/tests/flytekit/unit/engines/flyte/test_engine.py
@@ -258,7 +258,7 @@ def test_execution_annotation_overrides(mock_client_factory):
     )
 
 
-@patch.object(engine, '_SynchronousFlyteClient')
+@patch.object(engine._FlyteClientManager, '_CLIENT', new_callable=PropertyMock)
 def test_fetch_launch_plan(mock_client_factory):
     mock_client = MagicMock()
     mock_client.get_launch_plan = MagicMock(
@@ -277,4 +277,26 @@ def test_fetch_launch_plan(mock_client_factory):
 
     mock_client.get_launch_plan.assert_called_once_with(
         identifier.Identifier(identifier.ResourceType.LAUNCH_PLAN, "p", "d", "n", "v")
+    )
+
+
+@patch.object(engine._FlyteClientManager, '_CLIENT', new_callable=PropertyMock)
+def test_fetch_active_launch_plan(mock_client_factory):
+    mock_client = MagicMock()
+    mock_client.get_active_launch_plan = MagicMock(
+        return_value=_launch_plan_models.LaunchPlan(
+            identifier.Identifier(identifier.ResourceType.LAUNCH_PLAN, "p1", "d1", "n1", "v1"),
+            MagicMock(),
+            MagicMock(),
+        )
+    )
+    mock_client_factory.return_value = mock_client
+
+    lp = engine.FlyteEngineFactory().fetch_launch_plan(
+        identifier.Identifier(identifier.ResourceType.LAUNCH_PLAN, "p", "d", "n", "")
+    )
+    assert lp.id == identifier.Identifier(identifier.ResourceType.LAUNCH_PLAN, "p1", "d1", "n1", "v1")
+
+    mock_client.get_active_launch_plan.assert_called_once_with(
+        _common_models.NamedEntityIdentifier("p", "d", "n")
     )


### PR DESCRIPTION
* Implement client endpoints for get and list on active launch plans.
* Implement tool command to activate launch plans regardless of having a schedule or not.
* Implement SDK fetch() method to retrieve the active launch plan when looking for a non-specific version
* Deprecates existing activation command (activate-all-schedules) in favor of the new command.