### PR TITLE
Fix a Failing Unit Test for Configurations

### DIFF
--- a/flytekit/configuration/common.py
+++ b/flytekit/configuration/common.py
@@ -27,8 +27,9 @@ class FlyteConfigurationFile(object):
 
         :param Text location: used to load config from this location.
         """
-        self._location = location
+        self._location = None
         self._config = None
+        self.reset_config(location)
 
     def _load_config(self):
         if self._config is None and self._location:
@@ -84,11 +85,11 @@ class FlyteConfigurationFile(object):
                 pass
         return default
 
-    def reset_config(self, new_path):
+    def reset_config(self, location):
         """
-        :param Text new_path:
+        :param Text location:
         """
-        self._location = new_path
+        self._location = location or _os.environ.get('FLYTE_INTERNAL_CONFIGURATION_PATH')
         self._config = None
 
 

--- a/tests/flytekit/unit/configuration/conftest.py
+++ b/tests/flytekit/unit/configuration/conftest.py
@@ -1,0 +1,10 @@
+from __future__ import absolute_import
+from flytekit.configuration import set_flyte_config_file as _set_config
+import pytest as _pytest
+
+
+@_pytest.fixture(scope="function", autouse=True)
+def clear_configs():
+    _set_config(None)
+    yield
+    _set_config(None)


### PR DESCRIPTION
Also brings back the ability to find a config file that is at a path configured by default in the environment.