### PR TITLE
Loosen click version requirements

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 import flytekit.plugins
 
-__version__ = '0.1.8'
+__version__ = '0.1.9'

--- a/flytekit/clis/sdk_in_container/launch_plan.py
+++ b/flytekit/clis/sdk_in_container/launch_plan.py
@@ -170,7 +170,7 @@ def activate_all_impl(project, domain, version, pkgs):
         lp.update(_launch_plan_model.LaunchPlanState.ACTIVE)
 
 
-@click.command('activate-all-schedules', deprecated=True)
+@click.command('activate-all-schedules')
 @click.option('-v', '--version', type=str, help='Version to register tasks with. This is normally parsed from the'
                                                 'image, but you can override here.')
 @click.pass_context
@@ -180,6 +180,7 @@ def activate_all_schedules(ctx, version=None):
 
     The behavior of this command is identical to activate-all.
     """
+    click.secho("activate-all-schedules is deprecated, please used activate-all instead.", color="yellow")
     project = ctx.obj[_constants.CTX_PROJECT]
     domain = ctx.obj[_constants.CTX_DOMAIN]
     pkgs = ctx.obj[_constants.CTX_PACKAGES]

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     install_requires=[
         "sloth-import>=0.2.3,<1.0.0",
         "flyteidl>=0.14.0,<1.0.0",
-        "click>=7.0,<8.0",
+        "click>=6.6,<8.0",
         "configparser>=3.0.0,<4.0.0",
         "croniter>=0.3.20,<4.0.0",
         "deprecation>=2.0,<3.0",


### PR DESCRIPTION
In a previous version, click was upgraded to provide a deprecation message via the `click.command` decorator. However, this proved too limiting on users who had hard requirements on click versions. Therefore, allow older versions of click and just manually secho the deprecation message.