### PR TITLE
Remove Sloth-Import and Test Internal Implementation

### DIFF
--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -788,6 +788,7 @@ def list_active_launch_plans(project, domain, host, insecure, token, limit, show
         )
 
         for lp in active_lps:
+            print(lp)
             if urns_only:
                 _click.echo("{:80}".format(
                     _tt(_identifier.Identifier.promote_from_model(lp.id))
@@ -897,6 +898,31 @@ def get_launch_plan(urn, host, insecure):
     client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
     _click.echo(_tt(client.get_launch_plan(_identifier.Identifier.from_python_std(urn))))
     # TODO: Print launch plan pretty
+    _click.echo("")
+
+
+@_flyte_cli.command('get-active-launch-plan', cls=_FlyteSubCommand)
+@_project_option
+@_domain_option
+@_name_option
+@_host_option
+@_insecure_option
+def get_active_launch_plan(project, domain, name, host, insecure):
+    """
+    List the versions of all the launch plans under the scope specified by {project, domain}.
+    """
+    _welcome_message()
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+
+    lp = client.get_active_launch_plan(
+        _common_models.NamedEntityIdentifier(
+            project,
+            domain,
+            name
+        )
+    )
+    _click.echo("Active Launch Plan for {}:{}:{}\n".format(_tt(project), _tt(domain), _tt(name)))
+    _click.echo(lp)
     _click.echo("")
 
 

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -788,7 +788,6 @@ def list_active_launch_plans(project, domain, host, insecure, token, limit, show
         )
 
         for lp in active_lps:
-            print(lp)
             if urns_only:
                 _click.echo("{:80}".format(
                     _tt(_identifier.Identifier.promote_from_model(lp.id))

--- a/flytekit/common/tasks/sidecar_task.py
+++ b/flytekit/common/tasks/sidecar_task.py
@@ -11,8 +11,7 @@ from flytekit.common import sdk_bases as _sdk_bases
 from flytekit.models import task as _task_models
 from google.protobuf.json_format import MessageToDict as _MessageToDict
 
-import k8s.io.api.core.v1.generated_pb2 as _k8s_pb2
-import k8s.io.apimachinery.pkg.api.resource.generated_pb2 as _resource_pb2
+from flytekit.plugins import k8s as _lazy_k8s
 
 
 class SdkSidecarTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _sdk_runnable.SdkRunnableTask)):
@@ -93,7 +92,7 @@ class SdkSidecarTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _sdk_runnab
                 primary_exists = True
                 break
         if not primary_exists:
-            containers.extend([_k8s_pb2.Container(name=primary_container_name)])
+            containers.extend([_lazy_k8s.io.api.core.v1.generated_pb2.Container(name=primary_container_name)])
 
         final_containers = []
         for container in containers:
@@ -108,22 +107,22 @@ class SdkSidecarTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _sdk_runnab
                 del container.args[:]
                 container.args.extend(self._container.args)
 
-                resource_requirements = _k8s_pb2.ResourceRequirements()
+                resource_requirements = _lazy_k8s.io.api.core.v1.generated_pb2.ResourceRequirements()
                 for resource in self._container.resources.limits:
                     resource_requirements.limits[
                         _core_task.Resources.ResourceName.Name(resource.name).lower()].CopyFrom(
-                        _resource_pb2.Quantity(string=resource.value))
+                        _lazy_k8s.io.apimachinery.pkg.api.resource.generated_pb2.Quantity(string=resource.value))
                 for resource in self._container.resources.requests:
                     resource_requirements.requests[
                         _core_task.Resources.ResourceName.Name(resource.name).lower()].CopyFrom(
-                        _resource_pb2.Quantity(string=resource.value))
+                        _lazy_k8s.io.apimachinery.pkg.api.resource.generated_pb2.Quantity(string=resource.value))
                 if resource_requirements.ByteSize():
                     # Important! Only copy over resource requirements if they are non-empty.
                     container.resources.CopyFrom(resource_requirements)
 
                 del container.env[:]
                 container.env.extend(
-                    [_k8s_pb2.EnvVar(name=key, value=val) for key, val in
+                    [_lazy_k8s.io.api.core.v1.generated_pb2.EnvVar(name=key, value=val) for key, val in
                      _six.iteritems(self._container.env)])
 
             final_containers.append(container)

--- a/flytekit/common/types/impl/schema.py
+++ b/flytekit/common/types/impl/schema.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import
 
 import collections as _collections
-import numpy as _np
+from flytekit.plugins import numpy as _np
+from flytekit.plugins import pandas as _pd
 import os as _os
-import pandas as _pd
 import six as _six
 import uuid as _uuid
 

--- a/flytekit/models/task.py
+++ b/flytekit/models/task.py
@@ -5,7 +5,8 @@ import json as _json
 import six as _six
 from flyteidl.admin import task_pb2 as _admin_task
 from flyteidl.core import tasks_pb2 as _core_task, literals_pb2 as _literals_pb2, compiler_pb2 as _compiler
-from flyteidl.plugins import spark_pb2 as _spark_task, sidecar_pb2 as _sidecar_task
+from flyteidl.plugins import spark_pb2 as _spark_task
+from flytekit.plugins import flyteidl as _lazy_flyteidl
 from google.protobuf import json_format as _json_format, struct_pb2 as _struct
 
 from flytekit.models import common as _common, literals as _literals, interface as _interface
@@ -732,7 +733,7 @@ class SidecarJob(_common.FlyteIdlEntity):
         """
         :rtype: flyteidl.core.tasks_pb2.SidecarJob
         """
-        return _sidecar_task.SidecarJob(
+        return _lazy_flyteidl.plugins.sidecar_pb2.SidecarJob(
             pod_spec=self.pod_spec,
             primary_container_name=self.primary_container_name
         )

--- a/flytekit/plugins/__init__.py
+++ b/flytekit/plugins/__init__.py
@@ -1,33 +1,37 @@
 from __future__ import absolute_import
 from flytekit.tools import lazy_loader as _lazy_loader
 
-pyspark = _lazy_loader.LazyLoadPlugin(
+
+pyspark = _lazy_loader.lazy_load_module("pyspark")  # type: types.ModuleType
+
+k8s = _lazy_loader.lazy_load_module("k8s")  # type: types.ModuleType
+type(k8s).add_sub_module("io.api.core.v1.generated_pb2")
+type(k8s).add_sub_module("io.apimachinery.pkg.api.resource.generated_pb2")
+
+flyteidl = _lazy_loader.lazy_load_module("flyteidl")  # type: types.ModuleType
+type(flyteidl).add_sub_module("plugins.sidecar_pb2")
+
+numpy = _lazy_loader.lazy_load_module("numpy")  # type: types.ModuleType
+pandas = _lazy_loader.lazy_load_module("pandas")  # type: types.ModuleType
+
+_lazy_loader.LazyLoadPlugin(
     "spark",
     ["pyspark>=2.4.0,<3.0.0"],
-    [
-        "pyspark",
-    ]
+    [pyspark]
 )
 
-k8s = _lazy_loader.LazyLoadPlugin(
+_lazy_loader.LazyLoadPlugin(
     "sidecar",
     ["k8s-proto>=0.0.2,<1.0.0"],
-    [
-        "k8s.io.api.core.v1.generated_pb2",
-        "k8s.io.apimachinery.pkg.api.resource.generated_pb2",
-        "flyteidl.plugins.sidecar_pb2",
-    ]
+    [k8s, flyteidl]
 )
 
-schema = _lazy_loader.LazyLoadPlugin(
+_lazy_loader.LazyLoadPlugin(
     "schema",
     [
         "numpy>=1.14.0,<2.0.0",
         "pandas>=0.22.0,<1.0.0",
         "pyarrow>=0.11.0,<1.0.0",
     ],
-    [
-        "numpy",
-        "pandas",
-    ]
+    [numpy, pandas]
 )

--- a/flytekit/tools/lazy_loader.py
+++ b/flytekit/tools/lazy_loader.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 import importlib as _importlib
 import sys as _sys
+import types as _types
 
 
 class LazyLoadPlugin(object):
@@ -33,17 +34,17 @@ class LazyLoadPlugin(object):
 def lazy_load_module(module):
     """
     :param Text module: 
-    :rtype: types.ModuleType[T]
+    :rtype: _types.ModuleType
     """
-    class LazyLoadModule(_LazyLoadModule):   
+    class LazyLoadModule(_LazyLoadModule):
         _module = module
         _lazy_submodules = dict()
         _plugins = []
 
-    return LazyLoadModule()
+    return LazyLoadModule(module)
 
 
-class _LazyLoadModule(object):
+class _LazyLoadModule(_types.ModuleType):
 
     _ERROR_MSG_FMT = "Attempting to use a plugin functionality that requires module " \
                      "`{module}`, but it couldn't be loaded. Please pip install at least one of {plugins} or " \

--- a/flytekit/tools/lazy_loader.py
+++ b/flytekit/tools/lazy_loader.py
@@ -1,31 +1,21 @@
 from __future__ import absolute_import
-import os as _os
-
-if not _os.environ.get('FLYTEKIT_SETUP', None):
-    from lazy_import import lazy_module as _lazy_module
+import importlib as _importlib
+import sys as _sys
 
 
 class LazyLoadPlugin(object):
 
     LAZY_LOADING_PLUGINS = {}
-    _ERROR_MSG_FMT = "Attempting to use a plugin functionality that requires module " \
-                     "`{{module}}`, but it couldn't be loaded. Please `pip install flytekit[{plugin_name}]` or " \
-                     "`flytekit[all]` to get these dependencies."
 
-    def __init__(self, plugin_name, plugin_requirements, modules):
+    def __init__(self, plugin_name, plugin_requirements, related_modules):
         """
         :param Text plugin_name:
         :param list[Text] plugin_requirements:
-        :param list[Text] modules:
+        :param list[LazyLoadModule] related_modules:
         """
-        if not _os.environ.get('FLYTEKIT_SETUP', None):
-            self._lazy_modules = [
-                _lazy_module(module, error_strings={'msg': type(self)._ERROR_MSG_FMT.format(plugin_name=plugin_name)})
-                for module in modules
-            ]
-        else:
-            self._lazy_modules = []
         type(self).LAZY_LOADING_PLUGINS[plugin_name] = plugin_requirements
+        for m in related_modules:
+            type(m).tag_with_plugin(plugin_name)
 
     @classmethod
     def get_extras_require(cls):
@@ -38,3 +28,83 @@ class LazyLoadPlugin(object):
             all_plugins.extend(d[k])
         d['all'] = all_plugins
         return d
+
+
+def lazy_load_module(module):
+    """
+    :param Text module: 
+    :rtype: types.ModuleType[T]
+    """
+    class LazyLoadModule(_LazyLoadModule):   
+        _module = module
+        _lazy_submodules = dict()
+        _plugins = []
+
+    return LazyLoadModule()
+
+
+class _LazyLoadModule(object):
+
+    _ERROR_MSG_FMT = "Attempting to use a plugin functionality that requires module " \
+                     "`{module}`, but it couldn't be loaded. Please pip install at least one of {plugins} or " \
+                     "`flytekit[all]` to get these dependencies.\n" \
+                     "\n" \
+                     "Original message: {msg}"
+
+    @classmethod
+    def _load(cls):
+        module = _sys.modules.get(cls._module)
+        if not module:
+            try:
+                module = _importlib.import_module(cls._module)
+            except ImportError as e:
+                raise ImportError(
+                    cls._ERROR_MSG_FMT.format(
+                        module=cls._module,
+                        plugins=cls._plugins,
+                        msg=e
+                    )
+                )
+        return module
+
+    def __getattribute__(self, item):
+        if item in type(self)._lazy_submodules:
+            return type(self)._lazy_submodules[item]
+        m = type(self)._load()
+        return getattr(m, item)
+
+    def __setattr__(self, key, value):
+        m = type(self)._load()
+        return setattr(m, key, value)
+
+    @classmethod
+    def _add_sub_module(cls, submodule):
+        """
+        Add a submodule.
+        :param Text submodule:  This should be a single submodule. Do NOT include periods
+        :rtype: LazyLoadModule
+        """
+        m = cls._lazy_submodules.get(submodule)
+        if not m:
+            m = cls._lazy_submodules[submodule] = lazy_load_module("{}.{}".format(cls._module, submodule))
+        return m
+
+    @classmethod
+    def add_sub_module(cls, submodule):
+        """
+        Add a submodule.
+        :param Text submodule: If periods are included, it will be added recursively
+        :rtype: LazyLoadModule
+        """
+        parts = submodule.split(".", 1)
+        m = cls._add_sub_module(parts[0])
+        if len(parts) > 1:
+            m = type(m).add_sub_module(parts[1])
+        return m
+
+    @classmethod
+    def tag_with_plugin(cls, p):
+        """
+        :param LazyLoadPlugin p:
+        """
+        cls._plugins.append(p)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
 from __future__ import absolute_import
-import os
-os.environ["FLYTEKIT_SETUP"] = 'True'
 
 from setuptools import setup, find_packages  # noqa
 import flytekit  # noqa

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
         "pip>10.0.0,<19.2.0"
     ],
     install_requires=[
-        "sloth-import>=0.2.3,<1.0.0",
         "flyteidl>=0.14.0,<1.0.0",
         "click>=6.6,<8.0",
         "configparser>=3.0.0,<4.0.0",

--- a/tests/flytekit/unit/test_plugins.py
+++ b/tests/flytekit/unit/test_plugins.py
@@ -1,31 +1,31 @@
 from __future__ import absolute_import
-from lazy_import import LazyModule
-import flytekit  # noqa
+from flytekit import plugins
+from flytekit.tools import lazy_loader
 import pytest
 
 
 @pytest.mark.run(order=0)
 def test_spark_plugin():
+    plugins.pyspark.SparkContext
     import pyspark
-    assert isinstance(pyspark, LazyModule)
-    pyspark.SparkContext
+    assert plugins.pyspark.SparkContext == pyspark.SparkContext
 
 
 @pytest.mark.run(order=1)
 def test_schema_plugin():
+    plugins.numpy.dtype
+    plugins.pandas.DataFrame
     import numpy
     import pandas
-    assert isinstance(numpy, LazyModule)
-    assert isinstance(pandas, LazyModule)
-    numpy.dtype
-    pandas.DataFrame()
+    assert plugins.numpy.dtype == numpy.dtype
+    assert pandas.DataFrame == pandas.DataFrame
 
 
 @pytest.mark.run(order=2)
 def test_sidecar_plugin():
+    assert isinstance(plugins.k8s.io.api.core.v1.generated_pb2, lazy_loader._LazyLoadModule)
+    assert isinstance(plugins.k8s.io.apimachinery.pkg.api.resource.generated_pb2, lazy_loader._LazyLoadModule)
     import k8s.io.api.core.v1.generated_pb2
     import k8s.io.apimachinery.pkg.api.resource.generated_pb2
-    assert isinstance(k8s.io.api.core.v1.generated_pb2, LazyModule)
-    assert isinstance(k8s.io.apimachinery.pkg.api.resource.generated_pb2, LazyModule)
     k8s.io.api.core.v1.generated_pb2.Container
     k8s.io.apimachinery.pkg.api.resource.generated_pb2.Quantity

--- a/tests/flytekit/unit/tools/test_lazy_loader.py
+++ b/tests/flytekit/unit/tools/test_lazy_loader.py
@@ -5,13 +5,14 @@ import six
 
 
 def test_lazy_loader_error_message():
+    lazy_mod = lazy_loader.lazy_load_module("made.up.module")
     lazy_loader.LazyLoadPlugin(
         "uninstalled_plugin",
         [],
-        ["made.up.module"]
+        [lazy_mod]
     )
     with pytest.raises(ImportError) as e:
-        import made.up.module as m
-        m.a
+        lazy_mod.some_bad_attr
 
-    assert 'flytekit[uninstalled_plugin]' in six.text_type(e)
+    assert 'uninstalled_plugin' in six.text_type(e)
+    assert 'flytekit[all]' in six.text_type(e)


### PR DESCRIPTION
Using an external lazy-load library was problematic because it had side-effectual behavior with imports outside the scope of `flytekit`.  Generally, the side-effects were harmless, but in more complicated projects using `numpy`, issues clearly began to arise.  To counteract this, I've implemented similar lazy-load behavior, but only for handles specifically known to `flytekit`.  Thus user-code that imports modules that we additionally lazy-load will be unaffected. Developers inside `flytekit` will be aware of the short-comings of lazy-loaded modules and should handle accordingly.

Also, added a CLI endpoint which got caught up in my commits and I'm too lazy to pull out into a separate PR.