### PR TITLE
Fix tests and instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ Flytekit is Python 2.7+ compatible, so when feasible, it is recommended to test 
 
 #### Setup (Do Once)
 ```bash
-virtualenv ~/.virtualenvs/flytekit2
-source ~/.virtualenvs/flytekit2/bin/activate
+virtualenv ~/.virtualenvs/flytekit
+source ~/.virtualenvs/flytekit/bin/activate
 python -m pip install -r requirements.txt
 python -m pip install -U .[all]
 ```
 
 #### Execute
 ```bash
-source ~/.virtualenvs/flytekit2/bin/activate
+source ~/.virtualenvs/flytekit/bin/activate
 python -m pytest tests/flytekit/unit
 ```

--- a/tests/flytekit/unit/common_tests/exceptions/test_scopes.py
+++ b/tests/flytekit/unit/common_tests/exceptions/test_scopes.py
@@ -17,27 +17,27 @@ def _system_func(ex_to_raise):
 def test_base_scope():
     with pytest.raises(ValueError) as e:
         _user_func(ValueError("Bad value"))
-    assert "Bad value" in str(e)
+    assert "Bad value" in str(e.value)
 
     with pytest.raises(ValueError) as e:
         _system_func(ValueError("Bad value"))
-    assert "Bad value" in str(e)
+    assert "Bad value" in str(e.value)
 
     with pytest.raises(user.FlyteAssertion) as e:
         _user_func(user.FlyteAssertion("Bad assert"))
-    assert "Bad assert" in str(e)
+    assert "Bad assert" in str(e.value)
 
     with pytest.raises(system.FlyteSystemAssertion) as e:
         _user_func(system.FlyteSystemAssertion("Bad assert"))
-    assert "Bad assert" in str(e)
+    assert "Bad assert" in str(e.value)
 
     with pytest.raises(user.FlyteAssertion) as e:
         _system_func(user.FlyteAssertion("Bad assert"))
-    assert "Bad assert" in str(e)
+    assert "Bad assert" in str(e.value)
 
     with pytest.raises(system.FlyteSystemAssertion) as e:
         _system_func(system.FlyteSystemAssertion("Bad assert"))
-    assert "Bad assert" in str(e)
+    assert "Bad assert" in str(e.value)
 
 
 @scopes.user_entry_point

--- a/tests/flytekit/unit/tools/test_lazy_loader.py
+++ b/tests/flytekit/unit/tools/test_lazy_loader.py
@@ -14,5 +14,5 @@ def test_lazy_loader_error_message():
     with pytest.raises(ImportError) as e:
         lazy_mod.some_bad_attr
 
-    assert 'uninstalled_plugin' in six.text_type(e)
-    assert 'flytekit[all]' in six.text_type(e)
+    assert 'uninstalled_plugin' in six.text_type(e.value)
+    assert 'flytekit[all]' in six.text_type(e.value)


### PR DESCRIPTION
I just went through the README to get myself setup for this repo and found a few issues. This PR fixes -

* ~requirements.txt so it contains all the packages needed to run the tests (presumably this file is only used for dev as it previously had pytest in it)~ looks like this was fixed recently
* tests so they assert exception messages properly. _Looks like this was changed between pytest 4 and pytest 5._ The repo now pins to pytest 4, so these tests currently work, although this change is backwards compatible
* README to reference `flytekit` instead of `flytekit2`

---

I should've gotten the latest changes before creating this PR :) The remaining changes are pretty minor, so don't mind if we close this instead.