### PR TITLE
Remove redundant args and narrow scope

### DIFF
--- a/flytekit/clis/sdk_in_container/pyflyte.py
+++ b/flytekit/clis/sdk_in_container/pyflyte.py
@@ -13,7 +13,7 @@ except ImportError:
 from flytekit.clis.sdk_in_container.constants import CTX_PACKAGES
 from flytekit.clis.sdk_in_container.register import register
 from flytekit.clis.sdk_in_container.serialize import serialize
-from flytekit.clis.sdk_in_container.constants import CTX_PROJECT, CTX_DOMAIN, CTX_TEST, CTX_VERSION
+from flytekit.clis.sdk_in_container.constants import CTX_PROJECT, CTX_DOMAIN, CTX_VERSION
 from flytekit.clis.sdk_in_container.launch_plan import launch_plans
 from flytekit.configuration import internal as _internal_config, platform as _platform_config
 
@@ -36,9 +36,8 @@ from flytekit.configuration.sdk import WORKFLOW_PACKAGES as _WORKFLOW_PACKAGES
 @click.option('-v', '--version', required=False, type=str, help='This is the version to apply globally for this '
                                                                 'context')
 @click.option('-i', '--insecure', required=False, type=bool, help='Do not use SSL to connect to Admin')
-@click.option('--test', is_flag=True, help='Dry run, do not actually register with Admin')
 @click.pass_context
-def main(ctx, project, domain, config=None, pkgs=None, version=None, insecure=None, test=False):
+def main(ctx, project, domain, config=None, pkgs=None, version=None, insecure=None):
     """
     Entrypoint for all the user commands.
     """
@@ -47,7 +46,6 @@ def main(ctx, project, domain, config=None, pkgs=None, version=None, insecure=No
     ctx.obj = dict()
     ctx.obj[CTX_PROJECT] = project
     ctx.obj[CTX_DOMAIN] = domain
-    ctx.obj[CTX_TEST] = test
     version = version or _look_up_version_from_image_tag(_IMAGE.get())
     ctx.obj[CTX_VERSION] = version
 

--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -36,17 +36,20 @@ def register_tasks_only(project, domain, pkgs, test, version):
         t.register(project, domain, _utils.fqdn(m.__name__, k, entity_type=t.resource_type), version)
 
 
-
 @click.group('register')
+@click.option('--pkgs', multiple=True, hidden=True)  # DEPRECATED, use same arg on pyflyte.main instead
 @click.option('--test', is_flag=True, help='Dry run, do not actually register with Admin')
 @click.pass_context
-def register(ctx, test=None):
+def register(ctx, pkgs=None, test=None):
     """
     Run registration steps for the workflows in this container.
 
     Run with the --test switch for a dry run to see what will be registered.  A default launch plan will also be
     created, if a role can be found in the environment variables.
     """
+    if pkgs is not None:
+        raise ValueError("--pkgs must now be specified before the 'register' keyword on the command line")
+
     ctx.obj[CTX_TEST] = test
 
 

--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -37,7 +37,8 @@ def register_tasks_only(project, domain, pkgs, test, version):
 
 
 @click.group('register')
-@click.option('--pkgs', multiple=True, hidden=True)  # DEPRECATED, use same arg on pyflyte.main instead
+# --pkgs on the register group is DEPRECATED, use same arg on pyflyte.main instead
+@click.option('--pkgs', multiple=True, hidden=True)
 @click.option('--test', is_flag=True, help='Dry run, do not actually register with Admin')
 @click.pass_context
 def register(ctx, pkgs=None, test=None):
@@ -47,8 +48,8 @@ def register(ctx, pkgs=None, test=None):
     Run with the --test switch for a dry run to see what will be registered.  A default launch plan will also be
     created, if a role can be found in the environment variables.
     """
-    if pkgs is not None:
-        raise ValueError("--pkgs must now be specified before the 'register' keyword on the command line")
+    if pkgs:
+        raise click.UsageError("--pkgs must now be specified before the 'register' keyword on the command line")
 
     ctx.obj[CTX_TEST] = test
 

--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -36,20 +36,18 @@ def register_tasks_only(project, domain, pkgs, test, version):
         t.register(project, domain, _utils.fqdn(m.__name__, k, entity_type=t.resource_type), version)
 
 
-@click.group('register')
-@click.option('--pkgs', multiple=True, help='Comma separated list of dot separated python packages to operate on')
-@click.pass_context
-def register(ctx, pkgs=None):
-    """
-    Run registration steps for the workflow package location defined in this container.  Run with the --test switch
-    for a dry run to see what will be registered.  A default launch plan will also be created, if a role can be found
-    in the environment variables.
-    """
-    pkgs = pkgs or []
-    if len(pkgs) == 0:
-        pkgs = _WORKFLOW_PACKAGES.get()
 
-    ctx.obj[CTX_PACKAGES] = pkgs
+@click.group('register')
+@click.option('--test', is_flag=True, help='Dry run, do not actually register with Admin')
+@click.pass_context
+def register(ctx, test=None):
+    """
+    Run registration steps for the workflows in this container.
+
+    Run with the --test switch for a dry run to see what will be registered.  A default launch plan will also be
+    created, if a role can be found in the environment variables.
+    """
+    ctx.obj[CTX_TEST] = test
 
 
 @click.command('tasks')


### PR DESCRIPTION
I moved the `--test` flag into the `register` subcommand scope as it doesn't seem to apply anywhere else.

I also removed the duplicate `--pkgs` arg from the `register` subcommand, as it is already defined at the main command level. Having them in two places makes it confusing as when each one applies will depend on the order of the args, e.g.

```
pyflyte --pkgs common.workflows serialize
```

will work, but

```
pyflyte --pkgs common.workflows register workflows
```

will not because the redefinition of `--pkgs` at the `register` subcommand level will override it and reset it back to the default. (You would have to put `--pkgs` in between register and workflows for it to apply for the register subcommand as it stands before this PR.)

This is unfortunately a breaking change though, as it means `--pkgs` is no longer allowed after `register`, and must be specified before.