### PR TITLE
Implement the register --test arg

### DIFF
--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -20,8 +20,12 @@ def register_all(project, domain, pkgs, test, version):
 
     for m, k, o in iterate_registerable_entities_in_order(pkgs):
         name = _utils.fqdn(m.__name__, k, entity_type=o.resource_type)
-        click.echo("Registering {:20} {}".format("{}:".format(o.entity_type_text), name))
-        o.register(project, domain, name, version)
+
+        if test:
+            click.echo("Would register {:20} {}".format("{}:".format(o.entity_type_text), name))
+        else:
+            click.echo("Registering {:20} {}".format("{}:".format(o.entity_type_text), name))
+            o.register(project, domain, name, version)
 
 
 def register_tasks_only(project, domain, pkgs, test, version):
@@ -33,8 +37,13 @@ def register_tasks_only(project, domain, pkgs, test, version):
 
     # Discover all tasks by loading the module
     for m, k, t in iterate_registerable_entities_in_order(pkgs, include_entities={_task.SdkTask}):
-        t.register(project, domain, _utils.fqdn(m.__name__, k, entity_type=t.resource_type), version)
+        name = _utils.fqdn(m.__name__, k, entity_type=t.resource_type)
 
+        if test:
+            click.echo("Would register task {:20} {}".format("{}:".format(o.entity_type_text), name))
+        else:
+            click.echo("Registering task {:20} {}".format("{}:".format(o.entity_type_text), name))
+            t.register(project, domain, name, version)
 
 @click.group('register')
 # --pkgs on the register group is DEPRECATED, use same arg on pyflyte.main instead

--- a/tests/flytekit/unit/cli/pyflyte/test_register.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_register.py
@@ -1,0 +1,43 @@
+from click.testing import CliRunner
+import pytest
+from mock import MagicMock, PropertyMock, patch
+
+from flytekit.clis.sdk_in_container import constants as _constants
+from flytekit.engines.flyte import engine
+
+
+def test_register_workflows(mock_clirunner, monkeypatch):
+    mock_get_task = MagicMock()
+    monkeypatch.setattr(engine.FlyteEngineFactory, 'get_task', MagicMock(return_value=mock_get_task))
+    mock_get_workflow = MagicMock()
+    monkeypatch.setattr(engine.FlyteEngineFactory, 'get_workflow', MagicMock(return_value=mock_get_workflow))
+    mock_get_launch_plan = MagicMock()
+    monkeypatch.setattr(engine.FlyteEngineFactory, 'get_launch_plan', MagicMock(return_value=mock_get_launch_plan))
+
+    result = mock_clirunner('register', 'workflows')
+
+    assert result.exit_code == 0
+
+    assert len(mock_get_task.mock_calls) == 4
+    assert len(mock_get_task.register.mock_calls) == 4
+    assert len(mock_get_workflow.mock_calls) == 1
+    assert len(mock_get_workflow.register.mock_calls) == 1
+    assert len(mock_get_launch_plan.mock_calls) == 1
+    assert len(mock_get_launch_plan.register.mock_calls) == 1
+
+
+def test_register_workflows_with_test_switch(mock_clirunner, monkeypatch):
+    mock_get_task = MagicMock()
+    monkeypatch.setattr(engine.FlyteEngineFactory, 'get_task', MagicMock(return_value=mock_get_task))
+    mock_get_workflow = MagicMock()
+    monkeypatch.setattr(engine.FlyteEngineFactory, 'get_workflow', MagicMock(return_value=mock_get_workflow))
+    mock_get_launch_plan = MagicMock()
+    monkeypatch.setattr(engine.FlyteEngineFactory, 'get_launch_plan', MagicMock(return_value=mock_get_launch_plan))
+
+    result = mock_clirunner('register', '--test', 'workflows')
+
+    assert result.exit_code == 0
+
+    assert len(mock_get_task.mock_calls) == 0
+    assert len(mock_get_workflow.mock_calls) == 0
+    assert len(mock_get_launch_plan.mock_calls) == 0


### PR DESCRIPTION
This implements the `--test` functionality for the register subcommand. As it is now, the `--test` flag does nothing and workflows and tasks will be registered regardless of whether it is set.

I know there's some discussion about the usefulness of `--test` at all as full validation only happens server-side. I think there's still value to catch simple errors like missing imports, and also shows what Flyte has detected (to catch bad module paths, sys.path or missing `__init__.py` issues). Might need a better name though for clarity.

I also fixed a bug with a test mock - it mocks out flytekit.tools.module_loader.iterate_modules, which takes a sequence of names, but the mock only took in a single module name. It worked because there was also a mistake when specifying the value in the context.