### PR TITLE
Remove hidden arg from register --pkgs option

### DIFF
--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -47,7 +47,7 @@ def register_tasks_only(project, domain, pkgs, test, version):
 
 @click.group('register')
 # --pkgs on the register group is DEPRECATED, use same arg on pyflyte.main instead
-@click.option('--pkgs', multiple=True, hidden=True)
+@click.option('--pkgs', multiple=True, help="DEPRECATED. This arg can only be used before the 'register' keyword")
 @click.option('--test', is_flag=True, help='Dry run, do not actually register with Admin')
 @click.pass_context
 def register(ctx, pkgs=None, test=None):

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     ],
     install_requires=[
         "flyteidl>=0.15.0,<1.0.0",
-        "click>=7.0,<8.0",
+        "click>=6.6,<8.0",
         "configparser>=3.0.0,<4.0.0",
         "croniter>=0.3.20,<4.0.0",
         "deprecation>=2.0,<3.0",


### PR DESCRIPTION
The `hidden=True` arg on `@click.option` was only introduced in Click 7.0. Bumping flytekit up to this version led to an incompatibility with lyftlearnclient, a package commonly installed with flytekit, which requires v6.x.

Ideally lyftlearnclient would be updated to use Click 7.x, but I don't have the time to learn another package, so replacing the `hidden=True` arg with an angry `DEPRECATED` message is the next best option. It was only there for cosmetic reasons, so this doesn't affect the reason for the original change.

Slack thread - https://lyft.slack.com/archives/C3BLDHN92/p1573498574188800