### PR TITLE
Propagating error code instead of unknown

### DIFF
--- a/flytekit/common/exceptions/scopes.py
+++ b/flytekit/common/exceptions/scopes.py
@@ -74,12 +74,12 @@ class FlyteScopedException(Exception):
         """
         :rtype: Text
         """
-        if hasattr(self._exc_value, "error_code"):
+        if isinstance(self._exc_value, FlyteScopedException):
             return self._exc_value.error_code
-        elif hasattr(type(self._exc_value), "error_code"):
+
+        if hasattr(type(self._exc_value), "error_code"):
             return type(self._exc_value).error_code
-        else:
-            return "{}:Unknown".format(self._context)
+        return "{}:Unknown".format(self._context)
 
     @property
     def kind(self):

--- a/flytekit/common/exceptions/scopes.py
+++ b/flytekit/common/exceptions/scopes.py
@@ -74,9 +74,12 @@ class FlyteScopedException(Exception):
         """
         :rtype: Text
         """
-        if isinstance(self._exc_value, FlyteScopedException):
+        if hasattr(self._exc_value, "error_code"):
             return self._exc_value.error_code
-        return "{}:Unknown".format(self._context)
+        elif hasattr(type(self._exc_value), "error_code"):
+            return type(self._exc_value).error_code
+        else:
+            return "{}:Unknown".format(self._context)
 
     @property
     def kind(self):

--- a/tests/flytekit/unit/common_tests/exceptions/test_scopes.py
+++ b/tests/flytekit/unit/common_tests/exceptions/test_scopes.py
@@ -50,6 +50,7 @@ def test_intercepted_scope_non_flyte_exception():
     assert e.value == value_error
     assert "Bad value" in e.verbose_message
     assert "User error." in e.verbose_message
+    assert e.error_code == "USER:Unknown"
     assert e.kind == _error_models.ContainerError.Kind.NON_RECOVERABLE
 
     with pytest.raises(scopes.FlyteScopedSystemException) as e:
@@ -59,6 +60,7 @@ def test_intercepted_scope_non_flyte_exception():
     assert e.value == value_error
     assert "Bad value" in e.verbose_message
     assert "SYSTEM ERROR!" in e.verbose_message
+    assert e.error_code == "SYSTEM:Unknown"
     assert e.kind == _error_models.ContainerError.Kind.RECOVERABLE
 
 
@@ -72,6 +74,7 @@ def test_intercepted_scope_flyte_user_exception():
     assert e.value == assertion_error
     assert "Bad assert" in e.verbose_message
     assert "User error." in e.verbose_message
+    assert e.error_code == "USER:AssertionError"
     assert e.kind == _error_models.ContainerError.Kind.NON_RECOVERABLE
 
     with pytest.raises(scopes.FlyteScopedUserException) as e:
@@ -81,6 +84,7 @@ def test_intercepted_scope_flyte_user_exception():
     assert e.value == assertion_error
     assert "Bad assert" in e.verbose_message
     assert "User error." in e.verbose_message
+    assert e.error_code == "USER:AssertionError"
     assert e.kind == _error_models.ContainerError.Kind.NON_RECOVERABLE
 
 
@@ -95,6 +99,7 @@ def test_intercepted_scope_flyte_system_exception():
     assert "Bad assert" in e.verbose_message
     assert "SYSTEM ERROR!" in e.verbose_message
     assert e.kind == _error_models.ContainerError.Kind.RECOVERABLE
+    assert e.error_code == "SYSTEM:AssertionError"
 
     with pytest.raises(scopes.FlyteScopedSystemException) as e:
         _system_func(assertion_error)
@@ -103,4 +108,5 @@ def test_intercepted_scope_flyte_system_exception():
     assert e.value == assertion_error
     assert "Bad assert" in e.verbose_message
     assert "SYSTEM ERROR!" in e.verbose_message
+    assert e.error_code == "SYSTEM:AssertionError"
     assert e.kind == _error_models.ContainerError.Kind.RECOVERABLE


### PR DESCRIPTION
When we tried to raise our exception inherited from `FlyteUserException`, the error code is not propagated to the task execution as we always get `USER:unknown`. The PR is to address the issue.