### PR TITLE
Ability to customize image name

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 import flytekit.plugins
 
-__version__ = '0.3.0b2'
+__version__ = '0.3.1'

--- a/scripts/flytekit_build_image.sh
+++ b/scripts/flytekit_build_image.sh
@@ -19,9 +19,11 @@ echo ""
 # Go into the directory representing the user's repo
 pushd $1
 
-# Grab the repo name from the argument
+# Grab the repo name from the argument if not already defined
 # Note that this repo name will be the name of the Docker image.
-IMAGE_NAME=${PWD##*/}
+if [ -z "IMAGE_NAME" ]; then
+  IMAGE_NAME=${PWD##*/}
+fi
 
 # Do not do anything if there are unstaged git changes
 CHANGED=$(git status --porcelain)


### PR DESCRIPTION
This allows an override so that when we try to build images for git repos with multiple container images, we can customize the name.