### PR TITLE
Fix missing input error message

### DIFF
--- a/flytekit/common/interface.py
+++ b/flytekit/common/interface.py
@@ -118,7 +118,9 @@ class TypedInterface(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _interface_
         for k in sorted(self.inputs):
             var = self.inputs[k]
             if k not in map_of_bindings:
-                raise _user_exceptions.FlyteAssertion("Input was not specified for: {}".format(var))
+                raise _user_exceptions.FlyteAssertion(
+                    "Input was not specified for: {} of type {}".format(k, var.type)
+                )
 
             binding_data[k] = BindingData.from_python_std(
                 var.type,

--- a/tests/flytekit/unit/common_tests/tasks/test_sdk_runnable.py
+++ b/tests/flytekit/unit/common_tests/tasks/test_sdk_runnable.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import
 
 from flytekit.common import constants as _common_constants
+from flytekit.common.exceptions import user as _user_exceptions
 from flytekit.common.tasks import sdk_runnable
 from flytekit.common.types import primitives
 from flytekit.models import interface
+import pytest as _pytest
 
 
 def test_basic_unit_test():
@@ -34,3 +36,9 @@ def test_basic_unit_test():
     t.add_outputs({'value_out': interface.Variable(primitives.Integer.to_flyte_literal_type(), "")})
     out = t.unit_test(value_in=1)
     assert out['value_out'] == 2
+
+    with _pytest.raises(_user_exceptions.FlyteAssertion) as e:
+        t()
+
+    assert "value_in" in str(e.value)
+    assert "INTEGER" in str(e.value)


### PR DESCRIPTION
If a task is missing an input, the error message is currently -

```
Input was not specified for: type {
  simple: INTEGER
}
```

This updates that to include the name of the input that's missing -

```
Input was not specified for: value_in of type simple: INTEGER
```