### PR TITLE
Changes to Auth configurations

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 import flytekit.plugins
 
-__version__ = '0.4.1'
+__version__ = '0.4.2'

--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -129,7 +129,8 @@ class RawSynchronousFlyteClient(object):
             self.force_auth_flow()
 
     def set_access_token(self, access_token):
-        # Always set the header to lower-case regardless of what the config is.
+        # Always set the header to lower-case regardless of what the config is. The grpc libraries that Admin uses
+        # to parse the metadata don't change the metadata, but they do automatically lower the key you're looking for.
         self._metadata = [(_creds_config.AUTHORIZATION_METADATA_KEY.get().lower(), "Bearer {}".format(access_token))]
 
     def force_auth_flow(self):

--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -129,7 +129,8 @@ class RawSynchronousFlyteClient(object):
             self.force_auth_flow()
 
     def set_access_token(self, access_token):
-        self._metadata = [(_creds_config.AUTHORIZATION_METADATA_KEY.get(), "Bearer {}".format(access_token))]
+        # Always set the header to lower-case regardless of what the config is.
+        self._metadata = [(_creds_config.AUTHORIZATION_METADATA_KEY.get().lower(), "Bearer {}".format(access_token))]
 
     def force_auth_flow(self):
         refresh_handler_fn = _get_refresh_handler(_creds_config.AUTH_MODE.get())

--- a/flytekit/clis/auth/credentials.py
+++ b/flytekit/clis/auth/credentials.py
@@ -20,20 +20,25 @@ except ImportError:  # Python 2
 discovery_endpoint_path = ".well-known/oauth-authorization-server"
 
 
-def _get_discovery_endpoint():
+def _get_discovery_endpoint(http_config_val, platform_url_val, insecure_val):
 
-    if _HTTP_URL.get():
-        scheme, netloc, path, _, _, _ = _urlparse.urlparse(_HTTP_URL.get())
+    if http_config_val:
+        scheme, netloc, path, _, _, _ = _urlparse.urlparse(http_config_val)
         if not scheme:
-            scheme = 'http' if _INSECURE.get() else 'https'
+            scheme = 'http' if insecure_val else 'https'
 
-        computed_endpoint = _urlparse.urlunparse((scheme, netloc, path or discovery_endpoint_path, None, None, None))
+        if path:
+            print('====================in here ')
+            path = '/'.join([path, discovery_endpoint_path])
+        else:
+            path = discovery_endpoint_path
+        computed_endpoint = _urlparse.urlunparse((scheme, netloc, path, None, None, None))
         _logging.info('Using {} as discovery endpoint'.format(computed_endpoint))
         return computed_endpoint
 
-    if _INSECURE.get():
-        return _urlparse.urljoin('http://{}/'.format(_URL.get()), discovery_endpoint_path)
-    return _urlparse.urljoin('https://{}/'.format(_URL.get()), discovery_endpoint_path)
+    if insecure_val:
+        return _urlparse.urljoin('http://{}/'.format(platform_url_val), discovery_endpoint_path)
+    return _urlparse.urljoin('https://{}/'.format(platform_url_val), discovery_endpoint_path)
 
 
 # Lazy initialized authorization client singleton
@@ -54,6 +59,6 @@ def get_client():
 
 
 def get_authorization_endpoints():
-    discovery_endpoint = _get_discovery_endpoint()
+    discovery_endpoint = _get_discovery_endpoint(_HTTP_URL.get(), _URL.get(), _INSECURE.get())
     discovery_client = _DiscoveryClient(discovery_url=discovery_endpoint)
     return discovery_client.get_authorization_endpoints()

--- a/flytekit/clis/auth/credentials.py
+++ b/flytekit/clis/auth/credentials.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import logging
+import logging as _logging
 
 from flytekit.clis.auth.auth import AuthorizationClient as _AuthorizationClient
 from flytekit.clis.auth.discovery import DiscoveryClient as _DiscoveryClient
@@ -28,7 +28,7 @@ def _get_discovery_endpoint():
             scheme = 'http' if _INSECURE.get() else 'https'
 
         computed_endpoint = _urlparse.urlunparse((scheme, netloc, path or discovery_endpoint_path, None, None, None))
-        logging.info('Using {} as discovery endpoint'.format(computed_endpoint))
+        _logging.info('Using {} as discovery endpoint'.format(computed_endpoint))
         return computed_endpoint
 
     if _INSECURE.get():

--- a/flytekit/clis/auth/credentials.py
+++ b/flytekit/clis/auth/credentials.py
@@ -28,7 +28,6 @@ def _get_discovery_endpoint(http_config_val, platform_url_val, insecure_val):
             scheme = 'http' if insecure_val else 'https'
 
         if path:
-            print('====================in here ')
             path = '/'.join([path, discovery_endpoint_path])
         else:
             path = discovery_endpoint_path

--- a/flytekit/configuration/platform.py
+++ b/flytekit/configuration/platform.py
@@ -4,6 +4,16 @@ from flytekit.configuration import common as _config_common
 from flytekit.common import constants as _constants
 
 URL = _config_common.FlyteRequiredStringConfigurationEntry('platform', 'url')
+
+HTTP_URL = _config_common.FlyteStringConfigurationEntry('platform', 'http_url', default=None)
+"""
+If not starting with either http or https, this setting should begin with // as per the urlparse library and
+https://tools.ietf.org/html/rfc1808.html, otherwise the netloc will not be properly parsed.
+
+Currently the only use-case for this configuration setting is for Auth discovery. This setting supports the case where
+Flyte Admin's gRPC and HTTP points are deployed on different ports.
+"""
+
 INSECURE = _config_common.FlyteBoolConfigurationEntry('platform', 'insecure', default=False)
 
 CLOUD_PROVIDER = _config_common.FlyteStringConfigurationEntry(

--- a/tests/flytekit/unit/cli/auth/test_credentials.py
+++ b/tests/flytekit/unit/cli/auth/test_credentials.py
@@ -33,3 +33,9 @@ def test_get_discovery_endpoint():
 
     endpoint = _credentials._get_discovery_endpoint(None, 'flyte.corp.com', False)
     assert endpoint == 'https://flyte.corp.com/.well-known/oauth-authorization-server'
+
+    endpoint = _credentials._get_discovery_endpoint(None, 'localhost:8089', True)
+    assert endpoint == 'http://localhost:8089/.well-known/oauth-authorization-server'
+
+    endpoint = _credentials._get_discovery_endpoint(None, 'localhost:8089', False)
+    assert endpoint == 'https://localhost:8089/.well-known/oauth-authorization-server'

--- a/tests/flytekit/unit/cli/auth/test_credentials.py
+++ b/tests/flytekit/unit/cli/auth/test_credentials.py
@@ -16,8 +16,20 @@ def test_get_discovery_endpoint():
     endpoint = _credentials._get_discovery_endpoint('//localhost:8088/path', 'localhost:8089', False)
     assert endpoint == 'https://localhost:8088/path/.well-known/oauth-authorization-server'
 
+    endpoint = _credentials._get_discovery_endpoint('//flyte.corp.com', 'localhost:8089', False)
+    assert endpoint == 'https://flyte.corp.com/.well-known/oauth-authorization-server'
+
+    endpoint = _credentials._get_discovery_endpoint('//flyte.corp.com/path', 'localhost:8089', False)
+    assert endpoint == 'https://flyte.corp.com/path/.well-known/oauth-authorization-server'
+
     endpoint = _credentials._get_discovery_endpoint(None, 'localhost:8089', True)
     assert endpoint == 'http://localhost:8089/.well-known/oauth-authorization-server'
 
     endpoint = _credentials._get_discovery_endpoint(None, 'localhost:8089', False)
     assert endpoint == 'https://localhost:8089/.well-known/oauth-authorization-server'
+
+    endpoint = _credentials._get_discovery_endpoint(None, 'flyte.corp.com', True)
+    assert endpoint == 'http://flyte.corp.com/.well-known/oauth-authorization-server'
+
+    endpoint = _credentials._get_discovery_endpoint(None, 'flyte.corp.com', False)
+    assert endpoint == 'https://flyte.corp.com/.well-known/oauth-authorization-server'

--- a/tests/flytekit/unit/cli/auth/test_credentials.py
+++ b/tests/flytekit/unit/cli/auth/test_credentials.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import
+
+from flytekit.clis.auth import credentials as _credentials
+
+
+def test_get_discovery_endpoint():
+    endpoint = _credentials._get_discovery_endpoint('//localhost:8088', 'localhost:8089', True)
+    assert endpoint == 'http://localhost:8088/.well-known/oauth-authorization-server'
+
+    endpoint = _credentials._get_discovery_endpoint('//localhost:8088', 'localhost:8089', False)
+    assert endpoint == 'https://localhost:8088/.well-known/oauth-authorization-server'
+
+    endpoint = _credentials._get_discovery_endpoint('//localhost:8088/path', 'localhost:8089', True)
+    print(endpoint)
+    assert endpoint == 'http://localhost:8088/path/.well-known/oauth-authorization-server'
+
+    endpoint = _credentials._get_discovery_endpoint('//localhost:8088/path', 'localhost:8089', False)
+    assert endpoint == 'https://localhost:8088/path/.well-known/oauth-authorization-server'
+
+    endpoint = _credentials._get_discovery_endpoint(None, 'localhost:8089', True)
+    assert endpoint == 'http://localhost:8089/.well-known/oauth-authorization-server'
+
+    endpoint = _credentials._get_discovery_endpoint(None, 'localhost:8089', False)
+    assert endpoint == 'https://localhost:8089/.well-known/oauth-authorization-server'

--- a/tests/flytekit/unit/cli/auth/test_credentials.py
+++ b/tests/flytekit/unit/cli/auth/test_credentials.py
@@ -11,7 +11,6 @@ def test_get_discovery_endpoint():
     assert endpoint == 'https://localhost:8088/.well-known/oauth-authorization-server'
 
     endpoint = _credentials._get_discovery_endpoint('//localhost:8088/path', 'localhost:8089', True)
-    print(endpoint)
     assert endpoint == 'http://localhost:8088/path/.well-known/oauth-authorization-server'
 
     endpoint = _credentials._get_discovery_endpoint('//localhost:8088/path', 'localhost:8089', False)


### PR DESCRIPTION
I realized while testing things a bit more locally that just having one endpoint was insufficient - flyte-cli and pyflyte currently leverage the gRPC Python Flyte Admin client.  However, discovery needs the HTTP endpoint.  Even though in production both are served on the same endpoint and traffic is handled through ingress, this is not always the case, and we want to support the use-case where gRPC Admin and HTTP Admin are hosted separately.

We were debating just adding a separate config for discovery alone, but ultimately it makes more sense to split out the existing URL config into two objects, especially if the above pattern is something we want to continue to support.  However, in the interest of not making people migrate, and not writing migration code in this PR, we're just introducing the HTTP one for now.

Also, we should lowercase the metadata header before sending it to Admin in the gRPC calls.