### PR TITLE
Add option to write default config file

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 import flytekit.plugins
 
-__version__ = '0.4.2'
+__version__ = '0.4.3'

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -1531,6 +1531,11 @@ def register_project(identifier, name, description, host, insecure):
 @_host_option
 @_insecure_option
 def setup_config(client_id, redirect_uri, authorization_metadata_key, host, insecure):
+    """
+    Set-up a default config file.
+
+    """
+    _welcome_message()
     config_file = _get_config_file_path()
     if _get_user_filepath_home() and _os.path.exists(config_file):
         _click.secho("Config file already exists at {}".format(_tt(config_file)), fg='blue')

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -1497,7 +1497,7 @@ def register_project(identifier, name, description, host, insecure):
 @_flyte_cli.command('setup-config', cls=_click.Command)
 @_host_option
 @_insecure_option
-def setup_config(client_id, redirect_uri, authorization_metadata_key, host, insecure):
+def setup_config(host, insecure):
     """
     Set-up a default config file.
 


### PR DESCRIPTION
This change introduces a lookup against the admin `config/v1/flyte_client` endpoint to discover values necessary to write a config when it doesn't exist.