### PR TITLE
Fixing host and insecure flag handling

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 import flytekit.plugins
 
-__version__ = '0.4.2'
+__version__ = '0.4.3'

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -253,9 +253,9 @@ def _render_schedule_expr(lp):
 
 # These two flags are special in that they are specifiable in both the user's default ~/.flyte/config file, and in the
 # flyte-cli command itself, both in the parent-command position (flyte-cli) , and in the child-command position
-# (list-task-names). To get around this, first we read the value of the config object, and store it. Below are two
-# options for each of these options, one for the parent command, and one for the child command. If not set by the
-# parent, and also not set by the child, then the value from the config file is used.
+# (e.g. list-task-names). To get around this, first we read the value of the config object, and store it. Later in the
+# file below are options for each of these options, one for the parent command, and one for the child command. If not
+# set by the parent, and also not set by the child, then the value from the config file is used.
 #
 # For both host and insecure, command line values will override the setting in ~/.flyte/config file.
 #


### PR DESCRIPTION
Basically, this makes it so that,

* If you don't have a `~/.flyte/config` file...
  * `flyte-cli -h host.com` will use `host.com`
  * Not having a `-h` switch will fail
  * `flyte-cli --insecure` will use insecure connections
  * `flyte-cli` without `--insecure` will use secure.


* If you do have a `~/.flyte/config` file...
  * `flyte-cli -h host.com` will use `host.com`
  * Not having a `-h` switch will default to the value set in the config file.  If not set in the config file, the command will fail.
  * `flyte-cli --insecure` will use insecure connections
  * `flyte-cli` without `--insecure` will use the setting in the config file.  If not set in the config file, it will pick up the default, which is `False` and only use secure connections.




