### PR TITLE
Relax versions on sortedcontainers for py38

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "requests>=2.18.4,<3.0.0",
         "responses>=0.10.7",
         "six>=1.9.0,<2.0.0",
-        "sortedcontainers>=1.5.9,<2.0.0",
+        "sortedcontainers>=1.5.9,<3.0.0",
         "statsd>=3.0.0,<4.0.0",
         "urllib3>=1.22,<1.25",
         "wrapt>=1.0.0,<2.0.0",


### PR DESCRIPTION
```
/srv/venvs/service/trusty/service_venv_python3.7/lib/python3.7/site-packages/sortedcontainers/sortedlist.py:9
  /srv/venvs/service/trusty/service_venv_python3.7/lib/python3.7/site-packages/sortedcontainers/sortedlist.py:9: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Sequence, MutableSequence
```

This warning was fixed in version 2.0.5 of sortedcontainers. sortedcontainers promises to drop support
for python2 in the 3.0 release, so it should be safe to accept more versions.