### PR TITLE
Relax constraints on sortedcontainers for python3.8

### DIFF
--- a/flytekit/common/nodes.py
+++ b/flytekit/common/nodes.py
@@ -58,7 +58,7 @@ class ParameterMapper(_six.with_metaclass(_common_models.FlyteABCMeta, _SortedDi
         self._initialized = True
 
     def __getattr__(self, key):
-	if key == 'iteritems' and hasattr(super(ParameterMapper, self), 'items'):
+        if key == 'iteritems' and hasattr(super(ParameterMapper, self), 'items'):
            return super(ParameterMapper, self).items
         if hasattr(super(ParameterMapper, self), key):
             return getattr(super(ParameterMapper, self), key)

--- a/flytekit/common/nodes.py
+++ b/flytekit/common/nodes.py
@@ -58,8 +58,10 @@ class ParameterMapper(_six.with_metaclass(_common_models.FlyteABCMeta, _SortedDi
         self._initialized = True
 
     def __getattr__(self, key):
+	if key == 'iteritems' and hasattr(super(ParameterMapper, self), 'items'):
+           return super(ParameterMapper, self).items
         if hasattr(super(ParameterMapper, self), key):
-            return super(ParameterMapper, self).__getattr_(key)
+            return getattr(super(ParameterMapper, self), key)
         if key not in self:
             raise _user_exceptions.FlyteAssertion("{} doesn't exist.".format(key))
         return self[key]

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "requests>=2.18.4,<3.0.0",
         "responses>=0.10.7",
         "six>=1.9.0,<2.0.0",
-        "sortedcontainers>=1.5.9,<2.0.0",
+        "sortedcontainers>=1.5.9<3.0.0",
         "statsd>=3.0.0,<4.0.0",
         "urllib3>=1.22,<1.25",
         "wrapt>=1.0.0,<2.0.0",


### PR DESCRIPTION
As in version 2.0 the method was changed from `iteritems` to `items`, it seemed easiest to connect the two in `__getattr__` as `_six.items` doesn't exist.

The reason to upgrade sortedcontainers is to support python3.8: in that version, the path that it imports ABCs from will no longer exist: 
```
/srv/venvs/service/trusty/service_venv_python3.7/lib/python3.7/site-packages/sortedcontainers/sortedlist.py:9
  /srv/venvs/service/trusty/service_venv_python3.7/lib/python3.7/site-packages/sortedcontainers/sortedlist.py:9: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Sequence, MutableSequence
```


In addition, `super(ParameterMapper, self).__getattr_` doesn't exist. 