### PR TITLE
Bump pandas to 1.0.0

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 import flytekit.plugins
 
-__version__ = '0.4.7'
+__version__ = '0.5.0'

--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 import flytekit.plugins
 
-__version__ = '0.4.6'
+__version__ = '0.4.7'

--- a/flytekit/plugins/__init__.py
+++ b/flytekit/plugins/__init__.py
@@ -33,7 +33,7 @@ _lazy_loader.LazyLoadPlugin(
     "schema",
     [
         "numpy>=1.14.0,<2.0.0",
-        "pandas>=0.22.0,<1.0.0",
+        "pandas>=0.22.0,<2.0.0",
         "pyarrow>=0.11.0,<1.0.0",
     ],
     [numpy, pandas]


### PR DESCRIPTION
Pandas v1.0.1 is out. We would like to start consuming it in `etamodels`.