### PR TITLE
Append '/' to remote_path for gcs

### DIFF
--- a/flytekit/interfaces/data/gcs/gcs_proxy.py
+++ b/flytekit/interfaces/data/gcs/gcs_proxy.py
@@ -99,7 +99,12 @@ class GCSProxy(_common_data.DataProxy):
             raise ValueError("Not an GS Key. Please use FQN (GS ARN) of the format gs://...")
 
         GCSProxy._check_binary()
-        cmd = [GCSProxy._GS_UTIL_CLI, "cp", "-r", _amend_path(local_path), remote_path]
+
+        cmd = [GCSProxy._GS_UTIL_CLI,
+               "cp",
+               "-r",
+               _amend_path(local_path),
+               remote_path if remote_path.endswith("/") else remote_path + "/"]
         return _update_cmd_config_and_execute(cmd)
 
     def get_random_path(self):

--- a/tests/flytekit/unit/interfaces/data/gcs/test_gcs_proxy.py
+++ b/tests/flytekit/unit/interfaces/data/gcs/test_gcs_proxy.py
@@ -1,0 +1,43 @@
+from __future__ import absolute_import
+
+import os as _os
+
+import mock as _mock
+import pytest as _pytest
+from flytekit.interfaces.data.gcs import gcs_proxy as _gcs_proxy
+
+
+@_pytest.fixture
+def gcs_proxy():
+    return _gcs_proxy.GCSProxy()
+
+
+@_mock.patch("flytekit.interfaces.data.gcs.gcs_proxy._update_cmd_config_and_execute")
+def test_upload_directory(mock_update_cmd_config_and_execute, gcs_proxy):
+    local_path, remote_path = "/foo/*", "gs://bar/0/"
+    gcs_proxy.upload_directory(local_path, remote_path)
+    mock_update_cmd_config_and_execute.assert_called_once_with(
+        ["gsutil", "cp", "-r", local_path, remote_path]
+    )
+
+
+@_mock.patch("flytekit.interfaces.data.gcs.gcs_proxy._update_cmd_config_and_execute")
+def test_upload_directory_padding_wildcard_for_local_path(
+    mock_update_cmd_config_and_execute, gcs_proxy
+):
+    local_path, remote_path = "/foo", "gs://bar/0/"
+    gcs_proxy.upload_directory(local_path, remote_path)
+    mock_update_cmd_config_and_execute.assert_called_once_with(
+        ["gsutil", "cp", "-r", _os.path.join(local_path, "*"), remote_path]
+    )
+
+
+@_mock.patch("flytekit.interfaces.data.gcs.gcs_proxy._update_cmd_config_and_execute")
+def test_upload_directory_padding_slash_for_remote_path(
+    mock_update_cmd_config_and_execute, gcs_proxy
+):
+    local_path, remote_path = "/foo/*", "gs://bar/0"
+    gcs_proxy.upload_directory(local_path, remote_path)
+    mock_update_cmd_config_and_execute.assert_called_once_with(
+        ["gsutil", "cp", "-r", local_path, remote_path + "/"]
+    )

--- a/tests/flytekit/unit/interfaces/data/gcs/test_gcs_proxy.py
+++ b/tests/flytekit/unit/interfaces/data/gcs/test_gcs_proxy.py
@@ -8,11 +8,17 @@ from flytekit.interfaces.data.gcs import gcs_proxy as _gcs_proxy
 
 
 @_pytest.fixture
+def mock_update_cmd_config_and_execute():
+    p = _mock.patch("flytekit.interfaces.data.gcs.gcs_proxy._update_cmd_config_and_execute")
+    yield p.start()
+    p.stop()
+
+
+@_pytest.fixture
 def gcs_proxy():
     return _gcs_proxy.GCSProxy()
 
 
-@_mock.patch("flytekit.interfaces.data.gcs.gcs_proxy._update_cmd_config_and_execute")
 def test_upload_directory(mock_update_cmd_config_and_execute, gcs_proxy):
     local_path, remote_path = "/foo/*", "gs://bar/0/"
     gcs_proxy.upload_directory(local_path, remote_path)
@@ -21,7 +27,6 @@ def test_upload_directory(mock_update_cmd_config_and_execute, gcs_proxy):
     )
 
 
-@_mock.patch("flytekit.interfaces.data.gcs.gcs_proxy._update_cmd_config_and_execute")
 def test_upload_directory_padding_wildcard_for_local_path(
     mock_update_cmd_config_and_execute, gcs_proxy
 ):
@@ -32,7 +37,6 @@ def test_upload_directory_padding_wildcard_for_local_path(
     )
 
 
-@_mock.patch("flytekit.interfaces.data.gcs.gcs_proxy._update_cmd_config_and_execute")
 def test_upload_directory_padding_slash_for_remote_path(
     mock_update_cmd_config_and_execute, gcs_proxy
 ):


### PR DESCRIPTION
Problem: When flyte propeller set the `--output-prefix` to `{gcs_bucket}/propeller/{workflow_name}-development-{execution_id}/{task_name}/data/0`, gsutil write the `output.pb` to `/0` file instead of creating a new folder `0` and upload the file `output.pb` to the `0` folder. When flyte propeller trying to validate the '0' folder, it could not find `output.pb` file and fill the task.
Fix: Append `/` to the output dir fixes the issue