### PR TITLE
Don't modify resource names when generating sidecar pod spec

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 import flytekit.plugins
 
-__version__ = '0.5.1'
+__version__ = '0.5.2'

--- a/flytekit/common/tasks/sidecar_task.py
+++ b/flytekit/common/tasks/sidecar_task.py
@@ -110,11 +110,11 @@ class SdkSidecarTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _sdk_runnab
                 resource_requirements = _lazy_k8s.io.api.core.v1.generated_pb2.ResourceRequirements()
                 for resource in self._container.resources.limits:
                     resource_requirements.limits[
-                        _core_task.Resources.ResourceName.Name(resource.name).lower()].CopyFrom(
+                        _core_task.Resources.ResourceName.Name(resource.name)].CopyFrom(
                         _lazy_k8s.io.apimachinery.pkg.api.resource.generated_pb2.Quantity(string=resource.value))
                 for resource in self._container.resources.requests:
                     resource_requirements.requests[
-                        _core_task.Resources.ResourceName.Name(resource.name).lower()].CopyFrom(
+                        _core_task.Resources.ResourceName.Name(resource.name)].CopyFrom(
                         _lazy_k8s.io.apimachinery.pkg.api.resource.generated_pb2.Quantity(string=resource.value))
                 if resource_requirements.ByteSize():
                     # Important! Only copy over resource requirements if they are non-empty.

--- a/tests/flytekit/unit/sdk/tasks/test_sidecar_tasks.py
+++ b/tests/flytekit/unit/sdk/tasks/test_sidecar_tasks.py
@@ -61,7 +61,7 @@ def test_sidecar_task():
                                          '{{.outputPrefix}}']
     assert primary_container['volumeMounts'] == [{'mountPath': 'some/where', 'name': 'volume mount'}]
     assert {'name': 'foo', 'value': 'bar'} in primary_container['env']
-    assert primary_container['resources'] == {'requests': {'cpu': {'string': '10'}},
-                                              'limits': {'gpu': {'string': '2'}}}
+    assert primary_container['resources'] == {'requests': {'CPU': {'string': '10'}},
+                                              'limits': {'GPU': {'string': '2'}}}
     assert pod_spec['containers'][1]['name'] == 'another container'
     assert simple_sidecar_task.custom['primaryContainerName'] == 'a container'


### PR DESCRIPTION
Fixes https://github.com/lyft/flyte/issues/180 so that the vanilla flytekit `gpu_request` & `gpu_limit` attributes get respected in the primary sidecar container.

For background, we replace [GPU](https://github.com/lyft/flyteplugins/blob/master/go/tasks/pluginmachinery/flytek8s/container_helper.go#L22) requests/limits with the[ nvidia/gpu resource name](https://github.com/lyft/flyteplugins/blob/master/go/tasks/pluginmachinery/flytek8s/container_helper.go#L24).

Capitalization doesn't affect pod spec unmarshaling (tested in flyteplugins)