### PR TITLE
Enable queuing_budget in Workflow Metadata

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 import flytekit.plugins
 
-__version__ = '0.6.0'
+__version__ = '0.6.1b'

--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 import flytekit.plugins
 
-__version__ = '0.7.0b2'
+__version__ = '0.7.0b3'

--- a/flytekit/common/workflow.py
+++ b/flytekit/common/workflow.py
@@ -441,7 +441,7 @@ def _discover_workflow_components(workflow_class):
     return inputs, outputs, nodes
 
 
-def build_sdk_workflow_from_metaclass(metaclass, cls=None):
+def build_sdk_workflow_from_metaclass(metaclass, queuing_budget=None, cls=None):
     """
     :param T metaclass:
     :param cls: This is the class that will be instantiated from the inputs, outputs, and nodes.  This will be used
@@ -449,9 +449,10 @@ def build_sdk_workflow_from_metaclass(metaclass, cls=None):
     :rtype: SdkWorkflow
     """
     inputs, outputs, nodes = _discover_workflow_components(metaclass)
-
+    metadata = _workflow_models.WorkflowMetadata(queuing_budget) if queuing_budget else None
     return (cls or SdkWorkflow)(
         inputs=[i for i in sorted(inputs, key=lambda x: x.name)],
         outputs=[o for o in sorted(outputs, key=lambda x: x.name)],
-        nodes=[n for n in sorted(nodes, key=lambda x: x.id)]
+        nodes=[n for n in sorted(nodes, key=lambda x: x.id)],
+        metadata=metadata
     )

--- a/flytekit/common/workflow.py
+++ b/flytekit/common/workflow.py
@@ -446,6 +446,7 @@ def build_sdk_workflow_from_metaclass(metaclass, queuing_budget=None, cls=None):
     :param T metaclass:
     :param cls: This is the class that will be instantiated from the inputs, outputs, and nodes.  This will be used
         by users extending the base Flyte programming model. If set, it must be a subclass of SdkWorkflow.
+    :param queuing_budget datetime.timedelta: [Optional] Budget that specifies the amount of time a workflow can be queued up for execution.
     :rtype: SdkWorkflow
     """
     inputs, outputs, nodes = _discover_workflow_components(metaclass)

--- a/flytekit/models/core/workflow.py
+++ b/flytekit/models/core/workflow.py
@@ -446,17 +446,26 @@ class WorkflowNode(_common.FlyteIdlEntity):
 
 class WorkflowMetadata(_common.FlyteIdlEntity):
 
-    def __init__(self):
+    def __init__(self, queuing_budget):
         """
         Metadata for the workflow.
         """
-        pass
+        self._queuing_budget = queuing_budget
+
+    @property
+    def queuing_budget(self):
+        """
+        :rtype: datetime.timedelta
+        """
+        return self._queuing_budget
 
     def to_flyte_idl(self):
         """
         :rtype: flyteidl.core.workflow_pb2.WorkflowMetadata
         """
-        return _core_workflow.WorkflowMetadata()
+        workflow_metadata = _core_workflow.WorkflowMetadata()
+        workflow_metadata.queuing_budget.FromTimedelta(self.queuing_budget)
+        return workflow_metadata
 
     @classmethod
     def from_flyte_idl(cls, pb2_object):
@@ -464,7 +473,7 @@ class WorkflowMetadata(_common.FlyteIdlEntity):
         :param flyteidl.core.workflow_pb2.WorkflowMetadata pb2_object:
         :rtype: WorkflowMetadata
         """
-        return cls()
+        return cls(queuing_budget=pb2_object.queuing_budget.ToTimedelta())
 
 class WorkflowMetadataDefaults(_common.FlyteIdlEntity):
 

--- a/flytekit/models/core/workflow.py
+++ b/flytekit/models/core/workflow.py
@@ -446,7 +446,7 @@ class WorkflowNode(_common.FlyteIdlEntity):
 
 class WorkflowMetadata(_common.FlyteIdlEntity):
 
-    def __init__(self, queuing_budget):
+    def __init__(self, queuing_budget=None):
         """
         Metadata for the workflow.
         """
@@ -464,7 +464,8 @@ class WorkflowMetadata(_common.FlyteIdlEntity):
         :rtype: flyteidl.core.workflow_pb2.WorkflowMetadata
         """
         workflow_metadata = _core_workflow.WorkflowMetadata()
-        workflow_metadata.queuing_budget.FromTimedelta(self.queuing_budget)
+        if self._queuing_budget:
+            workflow_metadata.queuing_budget.FromTimedelta(self.queuing_budget)
         return workflow_metadata
 
     @classmethod

--- a/flytekit/models/core/workflow.py
+++ b/flytekit/models/core/workflow.py
@@ -449,6 +449,8 @@ class WorkflowMetadata(_common.FlyteIdlEntity):
     def __init__(self, queuing_budget=None):
         """
         Metadata for the workflow.
+        
+        :param queuing_budget datetime.timedelta: [Optional] Budget that specifies the amount of time a workflow can be queued up for execution.
         """
         self._queuing_budget = queuing_budget
 

--- a/flytekit/sdk/workflow.py
+++ b/flytekit/sdk/workflow.py
@@ -42,7 +42,7 @@ class Output(_common_workflow.Output):
         )
 
 
-def workflow_class(_workflow_metaclass=None, cls=None):
+def workflow_class(_workflow_metaclass=None, cls=None, queuing_budget=None):
     """
     This is a decorator for wrapping class definitions into workflows.
 
@@ -66,7 +66,7 @@ def workflow_class(_workflow_metaclass=None, cls=None):
     """
 
     def wrapper(metaclass):
-        wf = _common_workflow.build_sdk_workflow_from_metaclass(metaclass, cls=cls)
+        wf = _common_workflow.build_sdk_workflow_from_metaclass(metaclass, cls=cls, queuing_budget=queuing_budget)
         return wf
 
     if _workflow_metaclass is not None:
@@ -74,7 +74,7 @@ def workflow_class(_workflow_metaclass=None, cls=None):
     return wrapper
 
 
-def workflow(nodes, inputs=None, outputs=None, cls=None):
+def workflow(nodes, inputs=None, outputs=None, cls=None, queuing_budget=None):
     """
     This function provides a user-friendly interface for authoring workflows.
 
@@ -112,6 +112,7 @@ def workflow(nodes, inputs=None, outputs=None, cls=None):
     wf = (cls or _common_workflow.SdkWorkflow)(
         inputs=[v.rename_and_return_reference(k) for k, v in sorted(_six.iteritems(inputs or {}))],
         outputs=[v.rename_and_return_reference(k) for k, v in sorted(_six.iteritems(outputs or {}))],
-        nodes=[v.assign_id_and_return(k) for k, v in sorted(_six.iteritems(nodes))]
+        nodes=[v.assign_id_and_return(k) for k, v in sorted(_six.iteritems(nodes))],
+        metadata=_common_workflow._workflow_models.WorkflowMetadata(queuing_budget=queuing_budget) if queuing_budget else None
     )
     return wf

--- a/flytekit/sdk/workflow.py
+++ b/flytekit/sdk/workflow.py
@@ -62,6 +62,7 @@ def workflow_class(_workflow_metaclass=None, cls=None, queuing_budget=None):
     :param cls: This is the class that will be instantiated from the inputs, outputs, and nodes. This will be used
         by users extending the base Flyte programming model. If set, it must be a subclass of
         :py:class:`flytekit.common.workflow.SdkWorkflow`.
+    :param queuing_budget datetime.timedelta: [Optional] Budget that specifies the amount of time a workflow can be queued up for execution.
     :rtype: flytekit.common.workflow.SdkWorkflow
     """
 
@@ -107,6 +108,7 @@ def workflow(nodes, inputs=None, outputs=None, cls=None, queuing_budget=None):
     :param T cls: This is the class that will be instantiated from the inputs, outputs, and nodes. This will be used
         by users extending the base Flyte programming model. If set, it must be a subclass of
         :py:class:`flytekit.common.workflow.SdkWorkflow`.
+    :param queuing_budget datetime.timedelta: [Optional] Budget that specifies the amount of time a workflow can be queued up for execution.
     :rtype: flytekit.common.workflow.SdkWorkflow
     """
     wf = (cls or _common_workflow.SdkWorkflow)(

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         ]
     },
     install_requires=[
-        "flyteidl>=0.17.9,<1.0.0",
+        "flyteidl>=0.17.22,<1.0.0",
         "click>=6.6,<8.0",
         "croniter>=0.3.20,<4.0.0",
         "deprecation>=2.0,<3.0",

--- a/tests/flytekit/unit/models/core/test_workflow.py
+++ b/tests/flytekit/unit/models/core/test_workflow.py
@@ -27,7 +27,7 @@ def test_alias():
     assert obj2.alias == 'myalias'
     assert obj2.var == 'myvar'
 
-def test_workflow():
+def test_workflow_template():
     task = _workflow.TaskNode(reference_id=_generic_id)
     nm = _get_sample_node_metadata()
     int_type = _types.LiteralType(_types.SimpleType.INTEGER)
@@ -58,7 +58,7 @@ def test_workflow():
     obj2 = _workflow.WorkflowTemplate.from_flyte_idl(obj.to_flyte_idl())
     assert obj2 == obj
 
-def test_workflow_with_queuing_budget():
+def test_workflow_template_with_queuing_budget():
     task = _workflow.TaskNode(reference_id=_generic_id)
     nm = _get_sample_node_metadata()
     int_type = _types.LiteralType(_types.SimpleType.INTEGER)

--- a/tests/flytekit/unit/models/core/test_workflow.py
+++ b/tests/flytekit/unit/models/core/test_workflow.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from datetime import timedelta
 
-from flytekit.models import literals as _literals
+from flytekit.models import literals as _literals, types as _types, interface as _interface
 from flytekit.models.core import workflow as _workflow, identifier as _identifier, condition as _condition
 
 _generic_id = _identifier.Identifier(_identifier.ResourceType.WORKFLOW, "project", "domain", "name", "version")
@@ -27,6 +27,67 @@ def test_alias():
     assert obj2.alias == 'myalias'
     assert obj2.var == 'myvar'
 
+def test_workflow():
+    task = _workflow.TaskNode(reference_id=_generic_id)
+    nm = _get_sample_node_metadata()
+    int_type = _types.LiteralType(_types.SimpleType.INTEGER)
+    wf_metadata = _workflow.WorkflowMetadata()
+    wf_metadata_defaults = _workflow.WorkflowMetadataDefaults()
+    typed_interface = _interface.TypedInterface(
+        {'a': _interface.Variable(int_type, "description1")},
+        {
+            'b': _interface.Variable(int_type, "description2"),
+            'c': _interface.Variable(int_type, "description3")
+        }
+    )
+    wf_node = _workflow.Node(
+        id='some:node:id',
+        metadata=nm,
+        inputs=[],
+        upstream_node_ids=[],
+        output_aliases=[],
+        task_node=task
+    )
+    obj = _workflow.WorkflowTemplate(
+        id=_generic_id,
+        metadata=wf_metadata, 
+        metadata_defaults=wf_metadata_defaults,
+        interface=typed_interface,
+        nodes=[wf_node],
+        outputs=[])
+    obj2 = _workflow.WorkflowTemplate.from_flyte_idl(obj.to_flyte_idl())
+    assert obj2 == obj
+
+def test_workflow_with_queuing_budget():
+    task = _workflow.TaskNode(reference_id=_generic_id)
+    nm = _get_sample_node_metadata()
+    int_type = _types.LiteralType(_types.SimpleType.INTEGER)
+    wf_metadata = _workflow.WorkflowMetadata(queuing_budget=timedelta(seconds=10))
+    wf_metadata_defaults = _workflow.WorkflowMetadataDefaults()
+    typed_interface = _interface.TypedInterface(
+        {'a': _interface.Variable(int_type, "description1")},
+        {
+            'b': _interface.Variable(int_type, "description2"),
+            'c': _interface.Variable(int_type, "description3")
+        }
+    )
+    wf_node = _workflow.Node(
+        id='some:node:id',
+        metadata=nm,
+        inputs=[],
+        upstream_node_ids=[],
+        output_aliases=[],
+        task_node=task
+    )
+    obj = _workflow.WorkflowTemplate(
+        id=_generic_id,
+        metadata=wf_metadata, 
+        metadata_defaults=wf_metadata_defaults,
+        interface=typed_interface,
+        nodes=[wf_node],
+        outputs=[])
+    obj2 = _workflow.WorkflowTemplate.from_flyte_idl(obj.to_flyte_idl())
+    assert obj2 == obj
 
 def test_workflow_metadata_queuing_budget():
     obj = _workflow.WorkflowMetadata(queuing_budget=timedelta(seconds=10))

--- a/tests/flytekit/unit/models/core/test_workflow.py
+++ b/tests/flytekit/unit/models/core/test_workflow.py
@@ -29,7 +29,7 @@ def test_alias():
 
 
 def test_workflow_metadata():
-    obj = _workflow.WorkflowMetadata()
+    obj = _workflow.WorkflowMetadata(queuing_budget=timedelta(seconds=10))
     obj2 = _workflow.WorkflowMetadata.from_flyte_idl(obj.to_flyte_idl())
     assert obj == obj2
 

--- a/tests/flytekit/unit/models/core/test_workflow.py
+++ b/tests/flytekit/unit/models/core/test_workflow.py
@@ -28,11 +28,15 @@ def test_alias():
     assert obj2.var == 'myvar'
 
 
-def test_workflow_metadata():
+def test_workflow_metadata_queuing_budget():
     obj = _workflow.WorkflowMetadata(queuing_budget=timedelta(seconds=10))
     obj2 = _workflow.WorkflowMetadata.from_flyte_idl(obj.to_flyte_idl())
     assert obj == obj2
 
+def test_workflow_metadata():
+    obj = _workflow.WorkflowMetadata()
+    obj2 = _workflow.WorkflowMetadata.from_flyte_idl(obj.to_flyte_idl())
+    assert obj == obj2
 
 def test_task_node():
     obj = _workflow.TaskNode(reference_id=_generic_id)


### PR DESCRIPTION
# TL;DR
Allow a user to specify `queueing_budget` parameter for their workflow. This parameter corresponds to the amount of time a user is willing to wait for a workflow to be executed.

FlyteIDL PR: https://github.com/lyft/flyteidl/pull/50
## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/245

## Follow-up issue
_NA_

