### PR TITLE
Implement UpdateNamedEntity in flyte-cli

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 import flytekit.plugins
 
-__version__ = '0.7.0b1'
+__version__ = '0.7.1'

--- a/flytekit/clients/friendly.py
+++ b/flytekit/clients/friendly.py
@@ -559,10 +559,8 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
 
     def update_named_entity(self, resource_type, id, metadata):
         """
-        Updates a launch plan.  Currently, this can only be used to update a given launch plan's state (ACTIVE v.
-        INACTIVE) for schedules.  If a launch plan with a given project, domain, and name is set to ACTIVE,
-        then any other launch plan with the same project, domain, and name that was set to ACTIVE will be switched to
-        INACTIVE in one transaction.
+        Updates the metadata associated with a named entity.  A named entity is designated a resource, e.g. a workflow,
+        task or launch plan specified by {project, domain, name} across all versions of the resource.
 
         :param int resource_type: Enum value from flytekit.models.identifier.ResourceType
         :param flytekit.models.admin.named_entity.NamedEntityIdentifier id: identifier for named entity to update

--- a/flytekit/clients/friendly.py
+++ b/flytekit/clients/friendly.py
@@ -553,6 +553,31 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
 
     ####################################################################################################################
     #
+    #  Named Entity Endpoints
+    #
+    ####################################################################################################################
+
+    def update_named_entity(self, resource_type, id, metadata):
+        """
+        Updates a launch plan.  Currently, this can only be used to update a given launch plan's state (ACTIVE v.
+        INACTIVE) for schedules.  If a launch plan with a given project, domain, and name is set to ACTIVE,
+        then any other launch plan with the same project, domain, and name that was set to ACTIVE will be switched to
+        INACTIVE in one transaction.
+
+        :param int resource_type: Enum value from flytekit.models.identifier.ResourceType
+        :param flytekit.models.admin.named_entity.NamedEntityIdentifier id: identifier for named entity to update
+        :param flytekit.models.admin.named_entity.NamedEntityIdentifierMetadata metadata:
+        """
+        super(SynchronousFlyteClient, self).update_named_entity(
+            _common_pb2.NamedEntityUpdateRequest(
+                resource_type=resource_type,
+                id=id.to_flyte_idl(),
+                metadata=metadata.to_flyte_idl(),
+            )
+        )
+
+    ####################################################################################################################
+    #
     #  Execution Endpoints
     #
     ####################################################################################################################

--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -402,6 +402,20 @@ class RawSynchronousFlyteClient(object):
 
     ####################################################################################################################
     #
+    #  Named Entity Endpoints
+    #
+    ####################################################################################################################
+
+    @_handle_rpc_error
+    def update_named_entity(self, update_named_entity_request):
+        """
+        :param flyteidl.admin.common_pb2.NamedEntityUpdateRequest update_named_entity_request:
+        :rtype: flyteidl.admin.common_pb2.NamedEntityUpdateResponse
+        """
+        return self._stub.UpdateNamedEntity(update_named_entity_request, metadata=self._metadata)
+
+    ####################################################################################################################
+    #
     #  Workflow Execution Endpoints
     #
     ####################################################################################################################

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -1525,7 +1525,7 @@ def register_project(identifier, name, description, host, insecure):
 @_project_option
 @_domain_option
 @_optional_name_option
-def update_workflow(description, state, host, insecure, project, domain, name):
+def update_workflow_meta(description, state, host, insecure, project, domain, name):
     """
     Updates a workflow entity under the scope specified by {project, domain, name} across versions.
     """
@@ -1549,7 +1549,7 @@ def update_workflow(description, state, host, insecure, project, domain, name):
 @_project_option
 @_domain_option
 @_optional_name_option
-def update_task(description, host, insecure, project, domain, name):
+def update_task_meta(description, host, insecure, project, domain, name):
     """
     Updates a task entity under the scope specified by {project, domain, name} across versions.
     """
@@ -1569,7 +1569,7 @@ def update_task(description, host, insecure, project, domain, name):
 @_project_option
 @_domain_option
 @_optional_name_option
-def update_launch_plan(description, host, insecure, project, domain, name):
+def update_launch_plan_meta(description, host, insecure, project, domain, name):
     """
     Updates a launch plan entity under the scope specified by {project, domain, name} across versions.
     """

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -407,7 +407,7 @@ _named_entity_state_choice = _click.option(
     "--state",
     type=_click.Choice(["active", "archived"]),
     required=True,
-    help="Whether or not to set as active."
+    help="The state change to apply to a named entity"
 )
 _named_entity_description_option = _click.option(
     "--description",
@@ -1527,7 +1527,7 @@ def register_project(identifier, name, description, host, insecure):
 @_optional_name_option
 def update_workflow(description, state, host, insecure, project, domain, name):
     """
-    Updates a workflow entity under the scope specified by {project, domain, name}.
+    Updates a workflow entity under the scope specified by {project, domain, name} across versions.
     """
     _welcome_message()
     client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
@@ -1539,7 +1539,47 @@ def update_workflow(description, state, host, insecure, project, domain, name):
         _core_identifier.ResourceType.WORKFLOW,
         _named_entity.NamedEntityIdentifier(project, domain, name),
         _named_entity.NamedEntityMetadata(description, state))
-    _click.echo("Successfully updated")
+    _click.echo("Successfully updated workflow")
+
+
+@_flyte_cli.command('update-task', cls=_FlyteSubCommand)
+@_named_entity_description_option
+@_host_option
+@_insecure_option
+@_project_option
+@_domain_option
+@_optional_name_option
+def update_task(description, host, insecure, project, domain, name):
+    """
+    Updates a task entity under the scope specified by {project, domain, name} across versions.
+    """
+    _welcome_message()
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    client.update_named_entity(
+        _core_identifier.ResourceType.TASK,
+        _named_entity.NamedEntityIdentifier(project, domain, name),
+        _named_entity.NamedEntityMetadata(description, _named_entity.NamedEntityState.ACTIVE))
+    _click.echo("Successfully updated task")
+
+
+@_flyte_cli.command('update-launch-plan', cls=_FlyteSubCommand)
+@_named_entity_description_option
+@_host_option
+@_insecure_option
+@_project_option
+@_domain_option
+@_optional_name_option
+def update_launch_plan(description, host, insecure, project, domain, name):
+    """
+    Updates a launch plan entity under the scope specified by {project, domain, name} across versions.
+    """
+    _welcome_message()
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    client.update_named_entity(
+        _core_identifier.ResourceType.LAUNCH_PLAN,
+        _named_entity.NamedEntityIdentifier(project, domain, name),
+        _named_entity.NamedEntityMetadata(description, _named_entity.NamedEntityState.ACTIVE))
+    _click.echo("Successfully updated launch plan")
 
 
 @_flyte_cli.command('setup-config', cls=_click.Command)

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -14,7 +14,7 @@ from flytekit import __version__
 from flytekit.clients import friendly as _friendly_client
 from flytekit.clis.helpers import construct_literal_map_from_variable_map as _construct_literal_map_from_variable_map, \
     construct_literal_map_from_parameter_map as _construct_literal_map_from_parameter_map, \
-    parse_args_into_dict as _parse_args_into_dict, str2bool as _str2bool
+    parse_args_into_dict as _parse_args_into_dict
 from flytekit.common import utils as _utils, launch_plan as _launch_plan_common
 from flytekit.common.core import identifier as _identifier
 from flytekit.common.types import helpers as _type_helpers
@@ -23,9 +23,9 @@ from flytekit.configuration import platform as _platform_config
 from flytekit.configuration import set_flyte_config_file
 from flytekit.interfaces.data import data_proxy as _data_proxy
 from flytekit.models import common as _common_models, filters as _filters, launch_plan as _launch_plan, literals as \
-    _literals
+    _literals, named_entity as _named_entity
 from flytekit.models.admin import common as _admin_common
-from flytekit.models.core import execution as _core_execution_models
+from flytekit.models.core import execution as _core_execution_models, identifier as _core_identifier
 from flytekit.models.execution import ExecutionSpec as _ExecutionSpec, ExecutionMetadata as _ExecutionMetadata
 from flytekit.models.project import Project as _Project
 from flytekit.models.schedule import Schedule as _Schedule
@@ -402,6 +402,18 @@ _state_choice = _click.option(
     type=_click.Choice(["active", "inactive"]),
     required=True,
     help="Whether or not to set schedule as active."
+)
+_named_entity_state_choice = _click.option(
+    "--state",
+    type=_click.Choice(["active", "archived"]),
+    required=True,
+    help="Whether or not to set as active."
+)
+_named_entity_description_option = _click.option(
+    "--description",
+    required=False,
+    type=str,
+    help="Concise description for the entity."
 )
 _sort_by_option = _click.option(
     "--sort-by",
@@ -1503,6 +1515,31 @@ def register_project(identifier, name, description, host, insecure):
     client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
     client.register_project(_Project(identifier, name, description))
     _click.echo("Registered project [id: {}, name: {}, description: {}]".format(identifier, name, description))
+
+
+@_flyte_cli.command('update-workflow', cls=_FlyteSubCommand)
+@_named_entity_description_option
+@_named_entity_state_choice
+@_host_option
+@_insecure_option
+@_project_option
+@_domain_option
+@_optional_name_option
+def update_workflow(description, state, host, insecure, project, domain, name):
+    """
+    Updates a workflow entity under the scope specified by {project, domain, name}.
+    """
+    _welcome_message()
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    if state == "active":
+        state = _named_entity.NamedEntityState.ACTIVE
+    elif state == "archived":
+        state = _named_entity.NamedEntityState.ARCHIVED
+    client.update_named_entity(
+        _core_identifier.ResourceType.WORKFLOW,
+        _named_entity.NamedEntityIdentifier(project, domain, name),
+        _named_entity.NamedEntityMetadata(description, state))
+    _click.echo("Successfully updated")
 
 
 @_flyte_cli.command('setup-config', cls=_click.Command)

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -1517,7 +1517,7 @@ def register_project(identifier, name, description, host, insecure):
     _click.echo("Registered project [id: {}, name: {}, description: {}]".format(identifier, name, description))
 
 
-@_flyte_cli.command('update-workflow', cls=_FlyteSubCommand)
+@_flyte_cli.command('update-workflow-meta', cls=_FlyteSubCommand)
 @_named_entity_description_option
 @_named_entity_state_choice
 @_host_option
@@ -1542,7 +1542,7 @@ def update_workflow(description, state, host, insecure, project, domain, name):
     _click.echo("Successfully updated workflow")
 
 
-@_flyte_cli.command('update-task', cls=_FlyteSubCommand)
+@_flyte_cli.command('update-task-meta', cls=_FlyteSubCommand)
 @_named_entity_description_option
 @_host_option
 @_insecure_option
@@ -1562,7 +1562,7 @@ def update_task(description, host, insecure, project, domain, name):
     _click.echo("Successfully updated task")
 
 
-@_flyte_cli.command('update-launch-plan', cls=_FlyteSubCommand)
+@_flyte_cli.command('update-launch-plan-meta', cls=_FlyteSubCommand)
 @_named_entity_description_option
 @_host_option
 @_insecure_option

--- a/flytekit/models/named_entity.py
+++ b/flytekit/models/named_entity.py
@@ -1,0 +1,122 @@
+from flyteidl.admin import common_pb2 as _common
+
+from flytekit.models import common as _common_models
+
+
+class NamedEntityState(object):
+    ACTIVE = _common.NAMED_ENTITY_ACTIVE
+    ARCHIVED = _common.NAMED_ENTITY_ARCHIVED
+
+    @classmethod
+    def enum_to_string(cls, val):
+        """
+        :param int val:
+        :rtype: Text
+        """
+        if val == cls.ACTIVE:
+            return "ACTIVE"
+        elif val == cls.ARCHIVED:
+            return "ARCHIVED"
+        else:
+            return "<UNKNOWN>"
+
+
+class NamedEntityIdentifier(_common_models.FlyteIdlEntity):
+    def __init__(self, project, domain, name):
+        """
+        :param Text project:
+        :param Text domain:
+        :param Text name:
+        """
+        self._project = project
+        self._domain = domain
+        self._name = name
+
+    @property
+    def project(self):
+        """
+        :rtype: Text
+        """
+        return self._project
+
+    @property
+    def domain(self):
+        """
+        :rtype: Text
+        """
+        return self._domain
+
+    @property
+    def name(self):
+        """
+        :rtype: Text
+        """
+        return self._name
+
+    def to_flyte_idl(self):
+        """
+        :rtype: flyteidl.admin.common_pb2.NamedEntityIdentifier
+        """
+        return _common.NamedEntityIdentifier(
+            project=self.project,
+            domain=self.domain,
+            name=self.name,
+        )
+
+    @classmethod
+    def from_flyte_idl(cls, p):
+        """
+        :param flyteidl.core.common_pb2.NamedEntityIdentifier p:
+        :rtype: Identifier
+        """
+        return cls(
+            project=p.project,
+            domain=p.domain,
+            name=p.name,
+        )
+
+
+class NamedEntityMetadata(_common_models.FlyteIdlEntity):
+    def __init__(self, description, state):
+        """
+
+        :param Text description:
+        :param int state: enum value from NamedEntityState
+        """
+        self._description = description
+        self._state = state
+
+    @property
+    def description(self):
+        """
+        :rtype: Text
+        """
+        return self._description
+
+    @property
+    def state(self):
+        """
+        enum value from NamedEntityState
+        :rtype: int
+        """
+        return self._state
+
+    def to_flyte_idl(self):
+        """
+        :rtype: flyteidl.admin.common_pb2.NamedEntityMetadata
+        """
+        return _common.NamedEntityMetadata(
+            description=self.description,
+            state=self.state,
+        )
+
+    @classmethod
+    def from_flyte_idl(cls, p):
+        """
+        :param flyteidl.core.common_pb2.NamedEntityMetadata p:
+        :rtype: Identifier
+        """
+        return cls(
+            description=p.description,
+            state=p.state,
+        )

--- a/tests/flytekit/unit/models/test_named_entity.py
+++ b/tests/flytekit/unit/models/test_named_entity.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import
+
+from flytekit.models import named_entity
+
+
+def test_identifier():
+    obj = named_entity.NamedEntityIdentifier("proj", "development", "MyWorkflow")
+    obj2 = named_entity.NamedEntityIdentifier.from_flyte_idl(obj.to_flyte_idl())
+    assert obj == obj2
+
+def test_metadata():
+    obj = named_entity.NamedEntityMetadata("i am a description", named_entity.NamedEntityState.ACTIVE)
+    obj2 = named_entity.NamedEntityMetadata.from_flyte_idl(obj.to_flyte_idl())
+    assert obj == obj2


### PR DESCRIPTION
# TL;DR
This change implements setting/updating the description of a named entity.  For background, a NamedEntity includes a task, workflow or launch plan for a specific {Project, Domain, Name} combination across versions. NamedEntities for all resource types have mutable descriptions. Furthermore, workflows also have a state attribute which enables their visibility in the console.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description


## Tracking Issue
https://github.com/lyft/flyte/issues/235

## Follow-up issue
_NA_
