### PR TITLE
log the input name instead of value input

### DIFF
--- a/flytekit/common/tasks/sdk_runnable.py
+++ b/flytekit/common/tasks/sdk_runnable.py
@@ -492,8 +492,8 @@ class SdkRunnableTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _base_task
         for k, v in _six.iteritems(inputs):
             if not self._is_argname_in_function_definition(k):
                 raise _user_exceptions.FlyteValidationException(
-                    "The input '{}' was not specified in the task function.  Therefore, this input cannot be "
-                    "provided to the task.".format(v)
+                    "The input named '{}' was not specified in the task function.  Therefore, this input cannot be "
+                    "provided to the task.".format(k)
                 )
             if _type_helpers.get_sdk_type_from_literal_type(v.type) in type(self)._banned_inputs:
                 raise _user_exceptions.FlyteValidationException(


### PR DESCRIPTION
# TL;DR
The logging message was logging the Types instead of logging the name of the input, which is a more legible and precise error.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
I changed this in the Github UI. flytekit was logging a value of a dict instead of the key of the dict. I made the appropriate change.

