### PR TITLE
Image build script flag and remove 2.7 from travis, bug for serialize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-    - "2.7"
     - "3.6"
 install:
   - pip install -r requirements.txt

--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 import flytekit.plugins
 
-__version__ = '0.7.1b0'
+__version__ = '0.7.1b1'

--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -51,6 +51,8 @@ def serialize_tasks_only(project, domain, pkgs, version, folder=None):
         fname_index = str(i).zfill(zero_padded_length)
         fname = '{}_{}.pb'.format(fname_index, entity._id.name)
         click.echo('  Writing {} to\n    {}'.format(entity._id, fname))
+        if folder:
+            fname = _os.path.join(folder, fname)
         _write_proto_to_file(serialized, fname)
 
         identifier_fname = '{}_{}.identifier.pb'.format(fname_index, entity._id.name)
@@ -62,7 +64,7 @@ def serialize_tasks_only(project, domain, pkgs, version, folder=None):
 @system_entry_point
 def serialize_all(project, domain, pkgs, version, folder=None):
     """
-    In order to register, we have to comply with Admin's endpoints. Those endpoints take the following object. These
+    In order to register, we have to comply with Admin's endpoints. Those endpoints take the following objects. These
     flyteidl.admin.launch_plan_pb2.LaunchPlanSpec
     flyteidl.admin.workflow_pb2.WorkflowSpec
     flyteidl.admin.task_pb2.TaskSpec
@@ -105,6 +107,8 @@ def serialize_all(project, domain, pkgs, version, folder=None):
         fname_index = str(i).zfill(zero_padded_length)
         fname = '{}_{}.pb'.format(fname_index, entity._id.name)
         click.echo('  Writing {} to\n    {}'.format(entity._id, fname))
+        if folder:
+            fname = _os.path.join(folder, fname)
         _write_proto_to_file(serialized, fname)
 
         # Not everything serialized will necessarily have an identifier field in it, even though some do (like the

--- a/scripts/flytekit_build_image.sh
+++ b/scripts/flytekit_build_image.sh
@@ -58,7 +58,7 @@ if [ -n "$REGISTRY" ]; then
   echo "${IMAGE_NAME}:latest also tagged with ${FLYTE_INTERNAL_IMAGE}"
 
   # Also push if there's a registry to push to
-  if [[ "${REGISTRY}" == "docker.io"*  && ! -z "${NOPUSH}" ]]; then
+  if [[ "${REGISTRY}" == "docker.io"*  && -z "${NOPUSH}" ]]; then
     docker login --username="${DOCKERHUB_USERNAME}" --password="${DOCKERHUB_PASSWORD}"
   fi
   docker push "${FLYTE_INTERNAL_IMAGE}"

--- a/scripts/flytekit_build_image.sh
+++ b/scripts/flytekit_build_image.sh
@@ -58,7 +58,7 @@ if [ -n "$REGISTRY" ]; then
   echo "${IMAGE_NAME}:latest also tagged with ${FLYTE_INTERNAL_IMAGE}"
 
   # Also push if there's a registry to push to
-  if [[ "${REGISTRY}" == "docker.io"*  && -z "${NOPUSH}" ]]; then
+  if [[ "${REGISTRY}" == "docker.io"*  && ! -z "${NOPUSH}" ]]; then
     docker login --username="${DOCKERHUB_USERNAME}" --password="${DOCKERHUB_PASSWORD}"
   fi
   docker push "${FLYTE_INTERNAL_IMAGE}"

--- a/scripts/flytekit_build_image.sh
+++ b/scripts/flytekit_build_image.sh
@@ -58,7 +58,7 @@ if [ -n "$REGISTRY" ]; then
   echo "${IMAGE_NAME}:latest also tagged with ${FLYTE_INTERNAL_IMAGE}"
 
   # Also push if there's a registry to push to
-  if [[ "${REGISTRY}" == "docker.io"* ]]; then
+  if [[ "${REGISTRY}" == "docker.io"*  && -z "${NOPUSH}" ]]; then
     docker login --username="${DOCKERHUB_USERNAME}" --password="${DOCKERHUB_PASSWORD}"
   fi
   docker push "${FLYTE_INTERNAL_IMAGE}"


### PR DESCRIPTION
# TL;DR
Minor switch in `flytekit_build_image.sh` and removing python 2.7 tests.  Minor bug fix.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
Adding a switch to the image building script to not push even when a `REGISTRY` section is detected.  Currently the behavior is that if a `REGISTRY` is present, it'll automatically be pushed.  By not pushing users can build images locally, but still have the image tagged with the full name `docker.io/corp/myworkflow:<sha>`

Python 2.7 is no longer supported.

When the `-f/--folder` option is specified, only the Identifier file was being written there.  We need to write both files there.

## Tracking Issue
No issue, can create one, but minor cleanup only.

## Follow-up issue
NA
