### PR TITLE
File-based registration

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 import flytekit.plugins
 
-__version__ = '0.7.1b1'
+__version__ = '0.7.1b2'

--- a/flytekit/clients/friendly.py
+++ b/flytekit/clients/friendly.py
@@ -17,6 +17,14 @@ from flytekit.common.exceptions.user import FlyteAssertion as _FlyteAssertion
 
 class SynchronousFlyteClient(_RawSynchronousFlyteClient):
 
+    @property
+    def raw(self):
+        """
+        Gives access to the raw client
+        :rtype: flytekit.clients.raw.RawSynchronousFlyteClient
+        """
+        return super(SynchronousFlyteClient, self)
+
     ####################################################################################################################
     #
     #  Task Endpoints
@@ -50,35 +58,6 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
             _task_pb2.TaskCreateRequest(
                 id=task_identifer.to_flyte_idl(),
                 spec=task_spec.to_flyte_idl()
-            )
-        )
-
-    def create_task_raw(
-            self,
-            task_identifier,
-            task_spec
-    ):
-        """
-        This is the raw version of the create method above. Used in situations where you already have an IDL object.
-
-        .. note ::
-
-            Overwrites are not supported so any request for a given project, domain, name, and version that exists in
-            the database must match the existing definition exactly. Furthermore, as long as the request
-            remains identical, calling this method multiple times will result in success.
-
-        :param flyteidl.core.identifier_pb2.Identifier task_identifier: The identifier for this task.
-        :param flyteidl.admin.task_pb2.TaskSpec task_spec: This is the actual definition of the task that
-            should be created.
-        :raises flytekit.common.exceptions.user.FlyteEntityAlreadyExistsException: If an identical version of the
-            task is found, this exception is raised.  The client might choose to ignore this exception because the
-            identical task is already registered.
-        :raises grpc.RpcError:
-        """
-        super(SynchronousFlyteClient, self).create_task(
-            _task_pb2.TaskCreateRequest(
-                id=task_identifier,
-                spec=task_spec
             )
         )
 
@@ -231,29 +210,6 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
             )
         )
 
-    def create_workflow_raw(
-            self,
-            workflow_identifier,
-            workflow_spec
-    ):
-        """
-        This is just an internal method used for situations when you already have an IDL object, mirroring the above
-
-        :param: flyteidl.core.identifier_pb2.Identifier workflow_identifier: The identifier for this workflow.
-        :param: flyteidl.admin.workflow_pb2.WorkflowSpec workflow_spec: This is the actual definition of the workflow
-            that should be created.
-        :raises flytekit.common.exceptions.user.FlyteEntityAlreadyExistsException: If an identical version of the
-            workflow is found, this exception is raised.  The client might choose to ignore this exception because the
-            identical workflow is already registered.
-        :raises grpc.RpcError:
-        """
-        super(SynchronousFlyteClient, self).create_workflow(
-            _workflow_pb2.WorkflowCreateRequest(
-                id=workflow_identifier,
-                spec=workflow_spec
-            )
-        )
-
     def list_workflow_ids_paginated(
             self,
             project,
@@ -401,29 +357,6 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
             _launch_plan_pb2.LaunchPlanCreateRequest(
                 id=launch_plan_identifer.to_flyte_idl(),
                 spec=launch_plan_spec.to_flyte_idl()
-            )
-        )
-
-    def create_launch_plan_raw(
-            self,
-            launch_plan_identifier,
-            launch_plan_spec
-    ):
-        """
-        This is the private raw version of the function above, used for cases when you already have an idl object.
-
-        :param: flyteidl.core.identifier_pb2.Identifier launch_plan_identifier: The identifier for this launch plan.
-        :param: flyteidl.admin.launch_plan_pb2.LaunchPlanSpec launch_plan_spec: This is the actual definition of the
-            launch plan that should be created.
-        :raises flytekit.common.exceptions.user.FlyteEntityAlreadyExistsException: If an identical version of the
-            launch plan is found, this exception is raised.  The client might choose to ignore this exception because
-            the identical launch plan is already registered.
-        :raises grpc.RpcError:
-        """
-        super(SynchronousFlyteClient, self).create_launch_plan(
-            _launch_plan_pb2.LaunchPlanCreateRequest(
-                id=launch_plan_identifier,
-                spec=launch_plan_spec
             )
         )
 

--- a/flytekit/clients/friendly.py
+++ b/flytekit/clients/friendly.py
@@ -17,29 +17,6 @@ from flytekit.common.exceptions.user import FlyteAssertion as _FlyteAssertion
 
 class SynchronousFlyteClient(_RawSynchronousFlyteClient):
 
-    def register_entities(self, id_entity_list):
-        """
-
-        :param List[(flyteidl.core.identifier_pb2.Identifier, T)] id_entity_list: List of launch plans, tasks, and
-            workflow objects, each with an identifier, that you want to register.
-        :raises flytekit.common.exceptions.user.FlyteEntityAlreadyExistsException: If an identical version of the
-            entity is found, this exception is raised.  The client might choose to ignore this exception because the
-            identical task is already registered.
-        :raises flytekit.common.exceptions.userFlyteAssertion: If the ID given has a resource type that is not a task,
-            a launch plan, or a workflow, this exception will be raised.
-        """
-        for id, flyte_entity in id_entity_list:
-            if id.resource_type == _identifier_pb2.LAUNCH_PLAN:
-                self._create_launch_plan_raw(id, flyte_entity)
-            elif id.resource_type == _identifier_pb2.TASK:
-                self._create_task_raw(id, flyte_entity)
-            elif id.resource_type == _identifier_pb2.WORKFLOW:
-                self._create_workflow_raw(id, flyte_entity)
-            else:
-                raise _FlyteAssertion(f"Only tasks, launch plans, and workflows can be called with this function, "
-                                      f"resource type {id.resource_type} was passed")
-
-
     ####################################################################################################################
     #
     #  Task Endpoints
@@ -76,7 +53,7 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
             )
         )
 
-    def _create_task_raw(
+    def create_task_raw(
             self,
             task_identifier,
             task_spec
@@ -254,7 +231,7 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
             )
         )
 
-    def _create_workflow_raw(
+    def create_workflow_raw(
             self,
             workflow_identifier,
             workflow_spec
@@ -427,7 +404,7 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
             )
         )
 
-    def _create_launch_plan_raw(
+    def create_launch_plan_raw(
             self,
             launch_plan_identifier,
             launch_plan_spec

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -1595,11 +1595,11 @@ def register_files(host, insecure, files):
     for id, flyte_entity in flyte_entities_list:
         try:
             if id.resource_type == _identifier_pb2.LAUNCH_PLAN:
-                client.create_launch_plan_raw(id, flyte_entity)
+                client.raw.create_launch_plan(_launch_plan_pb2.LaunchPlanCreateRequest(id=id, spec=flyte_entity))
             elif id.resource_type == _identifier_pb2.TASK:
-                client.create_task_raw(id, flyte_entity)
+                client.raw.create_task(_task_pb2.TaskCreateRequest(id=id, spec=flyte_entity))
             elif id.resource_type == _identifier_pb2.WORKFLOW:
-                client.create_workflow_raw(id, flyte_entity)
+                client.raw.create_workflow(_workflow_pb2.WorkflowCreateRequest(id=id, spec=flyte_entity))
             else:
                 raise _user_exceptions.FlyteAssertion(f"Only tasks, launch plans, and workflows can be called with this function, "
                                       f"resource type {id.resource_type} was passed")

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -1595,7 +1595,17 @@ def register_files(host, insecure, files):
         _click.echo(f"  {f}")
 
     flyte_entities_list = _extract_files(files)
-    client.register_entities(flyte_entities_list)
+    for id, flyte_entity in flyte_entities_list:
+        if id.resource_type == _identifier_pb2.LAUNCH_PLAN:
+            client.create_launch_plan_raw(id, flyte_entity)
+        elif id.resource_type == _identifier_pb2.TASK:
+            client.create_task_raw(id, flyte_entity)
+        elif id.resource_type == _identifier_pb2.WORKFLOW:
+            client.create_workflow_raw(id, flyte_entity)
+        else:
+            raise _FlyteAssertion(f"Only tasks, launch plans, and workflows can be called with this function, "
+                                  f"resource type {id.resource_type} was passed")
+
     _click.echo("Done with shit")
 
 

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -1520,10 +1520,9 @@ def register_project(identifier, name, description, host, insecure):
 
 def _extract_pair(identifier_file, object_file):
     """
-
-    :param identifier_file:
-    :param object_file:
-    :return:
+    :param Text identifier_file:
+    :param Text object_file:
+    :rtype: (flyteidl.core.identifier_pb2.Identifier, T)
     """
     resource_map = {
         _identifier_pb2.LAUNCH_PLAN: _launch_plan_pb2.LaunchPlanSpec,
@@ -1552,7 +1551,6 @@ def _extract_files(file_paths):
     for identifier_file in filename_iterator:
         object_file = next(filename_iterator)
         id, entity = _extract_pair(identifier_file, object_file)
-        # make click output.
         print(f'Id: {id} Entity: {entity}')
         results.append((id, entity))
 
@@ -1606,7 +1604,7 @@ def register_files(host, insecure, files):
             raise _FlyteAssertion(f"Only tasks, launch plans, and workflows can be called with this function, "
                                   f"resource type {id.resource_type} was passed")
 
-    _click.echo("Done with shit")
+    _click.echo(f"Finished registering {len(flyte_entities_list)} files")
 
 
 @_flyte_cli.command('update-workflow-meta', cls=_FlyteSubCommand)

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -1525,7 +1525,6 @@ def _extract_pair(identifier_file, object_file):
     :param object_file:
     :return:
     """
-    print(identifier_file, object_file)
     resource_map = {
         _identifier_pb2.LAUNCH_PLAN: _launch_plan_pb2.LaunchPlanSpec,
         _identifier_pb2.WORKFLOW: _workflow_pb2.WorkflowSpec,
@@ -1595,9 +1594,9 @@ def register_files(host, insecure, files):
     for f in files:
         _click.echo(f"  {f}")
 
-    object_list = _extract_files(files)
-
-    client.register_objects(object_list)
+    flyte_entities_list = _extract_files(files)
+    client.register_entities(flyte_entities_list)
+    _click.echo("Done with shit")
 
 
 @_flyte_cli.command('update-workflow-meta', cls=_FlyteSubCommand)

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -8,7 +8,8 @@ import stat as _stat
 import click as _click
 import six as _six
 
-from flyteidl.core import literals_pb2 as _literals_pb2
+from flyteidl.core import literals_pb2 as _literals_pb2, identifier_pb2 as _identifier_pb2
+from flyteidl.admin import launch_plan_pb2 as _launch_plan_pb2, workflow_pb2 as _workflow_pb2, task_pb2 as _task_pb2
 
 from flytekit import __version__
 from flytekit.clients import friendly as _friendly_client
@@ -1515,6 +1516,88 @@ def register_project(identifier, name, description, host, insecure):
     client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
     client.register_project(_Project(identifier, name, description))
     _click.echo("Registered project [id: {}, name: {}, description: {}]".format(identifier, name, description))
+
+
+def _extract_pair(identifier_file, object_file):
+    """
+
+    :param identifier_file:
+    :param object_file:
+    :return:
+    """
+    print(identifier_file, object_file)
+    resource_map = {
+        _identifier_pb2.LAUNCH_PLAN: _launch_plan_pb2.LaunchPlanSpec,
+        _identifier_pb2.WORKFLOW: _workflow_pb2.WorkflowSpec,
+        _identifier_pb2.TASK: _task_pb2.TaskSpec
+    }
+    id = _load_proto_from_file(_identifier_pb2.Identifier, identifier_file)
+    if not id.resource_type in resource_map:
+        raise _FlyteAssertion(f"Resource type found in identifier {id.resource_type} invalid, must be launch plan, "
+                              f"task, or workflow")
+    entity = _load_proto_from_file(resource_map[id.resource_type], object_file)
+    return id, entity
+
+
+def _extract_files(file_paths):
+    """
+    :param file_paths:
+    :rtype: List[(flyteidl.core.identifier_pb2.Identifier, T)]
+    """
+    # Get a manual iterator because we're going to grab files two at a time.
+    # The identifier file will always come first because the names are always the same and .identifier.pb sorts before
+    # .pb
+
+    results = []
+    filename_iterator = iter(file_paths)
+    for identifier_file in filename_iterator:
+        object_file = next(filename_iterator)
+        id, entity = _extract_pair(identifier_file, object_file)
+        # make click output.
+        print(f'Id: {id} Entity: {entity}')
+        results.append((id, entity))
+
+    return results
+
+
+@_flyte_cli.command('register-files', cls=_FlyteSubCommand)
+@_host_option
+@_insecure_option
+@_click.argument(
+    'files',
+    type=_click.Path(exists=True),
+    nargs=-1,
+)
+def register_files(host, insecure, files):
+    """
+    Given a list of files, this will (after sorting the input list), attempt to register them against Flyte Admin.
+    This command expects the files to be the output of the pyflyte serialize command.  See the code there for more
+    information. Valid files need to be:
+        * Ordered in the order that you want registration to happen. pyflyte should have done the topological sort
+          for you and produced file that have a prefix that sets the correct order.
+        * Of the correct type. That is, they should be the serialized form of one of these Flyte IDL objects
+          (or an identifier object).
+          - flyteidl.admin.launch_plan_pb2.LaunchPlanSpec for launch plans
+          - flyteidl.admin.workflow_pb2.WorkflowSpec for workflows
+          - flyteidl.admin.task_pb2.TaskSpec for tasks
+        * Each file needs to be accompanied by an identifier file. We can relax this constraint in the future.
+
+    :param host:
+    :param insecure:
+    :param files:
+    :return:
+    """
+    _welcome_message()
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    files = list(files)
+    files.sort()
+    _click.secho("Parsing files...", color='green', bold=True)
+    for f in files:
+        _click.echo(f"  {f}")
+
+    object_list = _extract_files(files)
+
+    client.register_objects(object_list)
 
 
 @_flyte_cli.command('update-workflow-meta', cls=_FlyteSubCommand)

--- a/scripts/flytekit_build_image.sh
+++ b/scripts/flytekit_build_image.sh
@@ -61,8 +61,11 @@ if [ -n "$REGISTRY" ]; then
   if [[ "${REGISTRY}" == "docker.io"*  && -z "${NOPUSH}" ]]; then
     docker login --username="${DOCKERHUB_USERNAME}" --password="${DOCKERHUB_PASSWORD}"
   fi
-  docker push "${FLYTE_INTERNAL_IMAGE}"
-  echo "${FLYTE_INTERNAL_IMAGE} pushed to remote"
+
+  if [[ -z "${NOPUSH}" ]]; then
+    docker push "${FLYTE_INTERNAL_IMAGE}"
+    echo "${FLYTE_INTERNAL_IMAGE} pushed to remote"
+  fi
 fi
 
 popd

--- a/tests/flytekit/unit/cli/test_flyte_cli.py
+++ b/tests/flytekit/unit/cli/test_flyte_cli.py
@@ -1,0 +1,66 @@
+from __future__ import absolute_import
+
+import mock as _mock
+import pytest
+
+from flytekit.clis.flyte_cli import main as _main
+from flytekit.common.types import primitives
+from flytekit.configuration import TemporaryConfiguration
+from flytekit.models.core import identifier as _core_identifier
+from flytekit.sdk.tasks import python_task, inputs, outputs
+from flytekit.common.exceptions.user import FlyteAssertion
+
+mm = _mock.MagicMock()
+mm.return_value=100
+
+
+def get_sample_task():
+    """
+    :rtype: flytekit.common.tasks.task.SdkTask
+    """
+    @inputs(a=primitives.Integer)
+    @outputs(b=primitives.Integer)
+    @python_task()
+    def my_task(wf_params, a, b):
+        b.set(a + 1)
+
+    return my_task
+
+
+@_mock.patch('flytekit.clis.flyte_cli.main._load_proto_from_file')
+def test__extract_files(load_mock):
+    id = _core_identifier.Identifier(_core_identifier.ResourceType.TASK, 'myproject', 'development', 'name', 'v')
+    t = get_sample_task()
+    with TemporaryConfiguration(
+            "",
+            internal_overrides={
+                'image': 'myflyteimage:v123',
+                'project': 'myflyteproject',
+                'domain': 'development'
+            }
+    ):
+        task_spec = t.serialize()
+
+    load_mock.side_effect = [id.to_flyte_idl(), task_spec]
+    new_id, entity = _main._extract_pair('a', 'b')
+    assert new_id == id.to_flyte_idl()
+    assert task_spec == entity
+
+
+@_mock.patch('flytekit.clis.flyte_cli.main._load_proto_from_file')
+def test__extract_files(load_mock):
+    id = _core_identifier.Identifier(_core_identifier.ResourceType.UNSPECIFIED, 'myproject', 'development', 'name', 'v')
+
+    load_mock.return_value = id.to_flyte_idl()
+    with pytest.raises(FlyteAssertion):
+        _main._extract_pair('a', 'b')
+
+
+def _identity_dummy(a, b):
+    return (a, b)
+
+
+@_mock.patch('flytekit.clis.flyte_cli.main._extract_pair', new=_identity_dummy)
+def test__extract_files():
+    results = _main._extract_files([1,2,3,4])
+    assert [(1, 2), (3, 4)] == results


### PR DESCRIPTION
# TL;DR
As detailed in the linked issue, this will take the output of the [previous pr](https://github.com/lyft/flytekit/pull/104) and register them with `flyte-cli`.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
This uses the same core logic as in the old registration path.  The only difference is that the data is read from files - files which follow a specific set of rules (detailed in help) - and the `to_flyte_idl()` call has already been made.

## Tracking Issue
https://github.com/lyft/flyte/issues/225

## Follow-up issue
NA
