### PR TITLE
Add condition to generation of dynamic job spec

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 import flytekit.plugins
 
-__version__ = '0.7.0'
+__version__ = '0.7.1'

--- a/flytekit/common/tasks/sdk_dynamic.py
+++ b/flytekit/common/tasks/sdk_dynamic.py
@@ -198,6 +198,7 @@ class SdkDynamicTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _sdk_runnab
                     if not node_output.sdk_node.id:
                         node_output.sdk_node.assign_id_and_return(node.id)
 
+                if len(sub_task_node.inputs) > 0:
                     # Upload inputs to working directory under /array_job.input_ref/inputs.pb
                     input_path = _os.path.join(node.id, _constants.INPUT_FILE_NAME)
                     generated_files[input_path] = _literal_models.LiteralMap(

--- a/flytekit/common/tasks/sdk_dynamic.py
+++ b/flytekit/common/tasks/sdk_dynamic.py
@@ -280,7 +280,7 @@ class SdkDynamicTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _sdk_runnab
         spec, generated_files = self._produce_dynamic_job_spec(context, inputs)
 
         # If no sub-tasks are requested to run, just produce an outputs file like any other single-step tasks.
-        if len(generated_files) == 0:
+        if len(generated_files) == 0 and len(spec.nodes) == 0:
             return {
                 _constants.OUTPUT_FILE_NAME: _literal_models.LiteralMap(
                     literals={binding.var: binding.binding.to_literal_model() for binding in spec.outputs})

--- a/tests/flytekit/unit/models/test_dynamic_wfs.py
+++ b/tests/flytekit/unit/models/test_dynamic_wfs.py
@@ -52,3 +52,37 @@ def test_dynamic_launch_plan_yielding():
     assert dj_spec.outputs[0].var == "out"
     assert dj_spec.outputs[0].binding.promise.node_id == node_id
     assert dj_spec.outputs[0].binding.promise.var == "task_output"
+
+
+@_tasks.python_task
+def empty_task(wf_params,):
+    wf_params.logging.info("Running empty task")
+
+
+@_workflow.workflow_class()
+class EmptyWorkflow(object):
+    empty_task_task_execution = empty_task()
+
+
+constant_workflow_lp = EmptyWorkflow.create_launch_plan()
+
+
+@_tasks.outputs(out=_Types.Integer)
+@_tasks.dynamic_task
+def lp_yield_empty_wf(wf_params, out):
+    wf_params.logging.info("Running inner task... yielding a launchplan for empty workflow")
+    constant_lp_yielding_task_execution = constant_workflow_lp()
+    yield constant_lp_yielding_task_execution
+    out.set(42)
+
+
+def test_dynamic_launch_plan_yielding_of_constant_workflow():
+    outputs = lp_yield_empty_wf.unit_test()
+    # TODO: Currently, Flytekit will not return early and not do anything if there are any workflow nodes detected
+    #   in the output of a dynamic task.
+    dj_spec = outputs[_sdk_constants.FUTURES_FILE_NAME]
+
+    assert len(dj_spec.nodes) == 1
+    assert len(dj_spec.outputs) == 1
+    assert dj_spec.outputs[0].var == "out"
+    assert len(outputs.keys()) == 1


### PR DESCRIPTION
# TL;DR
Please see the issue for a proper description.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
If a launch plan/subworkflow node does not have outputs, currently there is no dynamic job spec created.  This was the main issue this PR is meant to address.

Also discovered that if the workflow/launchplan yielded in a dynamic node does not have outputs, but does have inputs, those inputs would not be generated.  This was from improper indentation from the first time this code was created.

This code needs to be cleaned up... a lot.  See the follow-up issue.

## Tracking Issue
https://github.com/lyft/flyte/issues/282

## Follow up issue
https://github.com/lyft/flyte/issues/226
