### PR TITLE
Amend master version to 0.8.x

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 import flytekit.plugins
 
-__version__ = '0.7.1b2'
+__version__ = '0.8.0b0'


### PR DESCRIPTION
# TL;DR
Minor PR...

The 0.7.0 version of flytekit was deployed as part of Flyte milestone 0.3.0.  The features since then on master I'm going to try to make a full minor version increase, hence 0.8.0x, and reserve the 0.7.x moniker for patches.
