### PR TITLE
Add _sync_closure call to reduce load from wait_for_completion calls.

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 import flytekit.plugins
 
-__version__ = '0.8.0b1'
+__version__ = '0.8.0b2'

--- a/flytekit/common/nodes.py
+++ b/flytekit/common/nodes.py
@@ -414,3 +414,11 @@ class SdkNodeExecution(
                 _task_executions.SdkTaskExecution.promote_from_model(te) for te in ne.get_task_executions()
             ]
             # TODO: Sub-workflows too once implemented
+
+    def _sync_closure(self):
+        """
+        Syncs the closure of the underlying execution artifact with the state observed by the platform.
+        :rtype: None
+        """
+        ne = _engine_loader.get_engine().get_node_execution(self)
+        ne.sync()

--- a/flytekit/common/tasks/executions.py
+++ b/flytekit/common/tasks/executions.py
@@ -106,4 +106,11 @@ class SdkTaskExecution(
         )
 
     def sync(self):
+        self._sync_closure()
+
+    def _sync_closure(self):
+        """
+        Syncs the closure of the underlying execution artifact with the state observed by the platform.
+        :rtype: None
+        """
         _engine_loader.get_engine().get_task_execution(self).sync()

--- a/flytekit/common/workflow_execution.py
+++ b/flytekit/common/workflow_execution.py
@@ -123,8 +123,16 @@ class SdkWorkflowExecution(
         :rtype: None
         """
         if not self.is_complete or self._node_executions is None:
-            _engine_loader.get_engine().get_workflow_execution(self).sync()
+            self._sync_closure()
             self._node_executions = self.get_node_executions()
+
+    def _sync_closure(self):
+        """
+        Syncs the closure of the underlying execution artifact with the state observed by the platform.
+        :rtype: None
+        """
+        if not self.is_complete:
+            _engine_loader.get_engine().get_workflow_execution(self).sync()
 
     def get_node_executions(self, filters=None):
         """

--- a/flytekit/plugins/__init__.py
+++ b/flytekit/plugins/__init__.py
@@ -25,7 +25,7 @@ _lazy_loader.LazyLoadPlugin(
 
 _lazy_loader.LazyLoadPlugin(
     "sidecar",
-    ["k8s-proto>=0.0.2,<1.0.0"],
+    ["k8s-proto>=0.0.3,<1.0.0"],
     [k8s, flyteidl]
 )
 


### PR DESCRIPTION
# TL;DR
The `wait_for_completion` method calls a full sync every poll period even though a full sync is really only needed after the underlying closure indicates the artifact has transitioned to complete.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description


## Tracking Issue
https://github.com/lyft/flyte/issues/312

## Follow-up issue
_NA_
