### PR TITLE
Add FailurePolicy to WorkflowMetadata

### DIFF
--- a/flytekit/models/core/workflow.py
+++ b/flytekit/models/core/workflow.py
@@ -446,13 +446,20 @@ class WorkflowNode(_common.FlyteIdlEntity):
 
 class WorkflowMetadata(_common.FlyteIdlEntity):
 
-    def __init__(self, queuing_budget=None):
+    class OnFailurePolicy(object):
+        FAIL_IMMEDIATELY = _core_workflow.WorkflowMetadata.FAIL_IMMEDIATELY
+        FAIL_AFTER_RUNNING_NODES_COMPLETE = _core_workflow.WorkflowMetadata.FAIL_AFTER_RUNNING_NODES_COMPLETE
+        FAIL_AFTER_EXECUTABLE_NODES_COMPLETE = _core_workflow.WorkflowMetadata.FAIL_AFTER_EXECUTABLE_NODES_COMPLETE
+
+    def __init__(self, queuing_budget=None, on_failure=None):
         """
         Metadata for the workflow.
         
         :param queuing_budget datetime.timedelta: [Optional] Budget that specifies the amount of time a workflow can be queued up for execution.
+        :param on_fialure flytekit.models.core.workflow.WorkflowMetadata.OnFailurePolicy: [Optional] The execution policy when the workflow detects a failure.
         """
         self._queuing_budget = queuing_budget
+        self._on_failure = on_failure
 
     @property
     def queuing_budget(self):
@@ -461,6 +468,13 @@ class WorkflowMetadata(_common.FlyteIdlEntity):
         """
         return self._queuing_budget
 
+    @property
+    def on_failure(self):
+        """
+        :rtype: flytekit.models.core.workflow.WorkflowMetadata.OnFailurePolicy
+        """
+        return self._on_failure
+
     def to_flyte_idl(self):
         """
         :rtype: flyteidl.core.workflow_pb2.WorkflowMetadata
@@ -468,6 +482,8 @@ class WorkflowMetadata(_common.FlyteIdlEntity):
         workflow_metadata = _core_workflow.WorkflowMetadata()
         if self._queuing_budget:
             workflow_metadata.queuing_budget.FromTimedelta(self.queuing_budget)
+        if self.on_failure:
+            workflow_metadata.on_failure = self.on_failure
         return workflow_metadata
 
     @classmethod
@@ -476,7 +492,10 @@ class WorkflowMetadata(_common.FlyteIdlEntity):
         :param flyteidl.core.workflow_pb2.WorkflowMetadata pb2_object:
         :rtype: WorkflowMetadata
         """
-        return cls(queuing_budget=pb2_object.queuing_budget.ToTimedelta())
+        return cls(
+            queuing_budget=pb2_object.queuing_budget.ToTimedelta() if pb2_object.queuing_budget else None,
+            on_failure=pb2_object.on_failure if pb2_object.on_failure else WorkflowMetadata.OnFailurePolicy.FAIL_IMMEDIATELY
+        )
 
 class WorkflowMetadataDefaults(_common.FlyteIdlEntity):
 

--- a/flytekit/sdk/workflow.py
+++ b/flytekit/sdk/workflow.py
@@ -42,7 +42,7 @@ class Output(_common_workflow.Output):
         )
 
 
-def workflow_class(_workflow_metaclass=None, cls=None, queuing_budget=None):
+def workflow_class(_workflow_metaclass=None, cls=None, queuing_budget=None, on_failure=None):
     """
     This is a decorator for wrapping class definitions into workflows.
 
@@ -63,11 +63,12 @@ def workflow_class(_workflow_metaclass=None, cls=None, queuing_budget=None):
         by users extending the base Flyte programming model. If set, it must be a subclass of
         :py:class:`flytekit.common.workflow.SdkWorkflow`.
     :param queuing_budget datetime.timedelta: [Optional] Budget that specifies the amount of time a workflow can be queued up for execution.
+    :param on_fialure flytekit.models.core.workflow.WorkflowMetadata.OnFailurePolicy: [Optional] The execution policy when the workflow detects a failure.
     :rtype: flytekit.common.workflow.SdkWorkflow
     """
 
     def wrapper(metaclass):
-        wf = _common_workflow.build_sdk_workflow_from_metaclass(metaclass, cls=cls, queuing_budget=queuing_budget)
+        wf = _common_workflow.build_sdk_workflow_from_metaclass(metaclass, cls=cls, queuing_budget=queuing_budget, on_failure=on_failure)
         return wf
 
     if _workflow_metaclass is not None:
@@ -75,7 +76,7 @@ def workflow_class(_workflow_metaclass=None, cls=None, queuing_budget=None):
     return wrapper
 
 
-def workflow(nodes, inputs=None, outputs=None, cls=None, queuing_budget=None):
+def workflow(nodes, inputs=None, outputs=None, cls=None, queuing_budget=None, on_failure=None):
     """
     This function provides a user-friendly interface for authoring workflows.
 
@@ -109,6 +110,7 @@ def workflow(nodes, inputs=None, outputs=None, cls=None, queuing_budget=None):
         by users extending the base Flyte programming model. If set, it must be a subclass of
         :py:class:`flytekit.common.workflow.SdkWorkflow`.
     :param queuing_budget datetime.timedelta: [Optional] Budget that specifies the amount of time a workflow can be queued up for execution.
+    :param on_fialure flytekit.models.core.workflow.WorkflowMetadata.OnFailurePolicy: [Optional] The execution policy when the workflow detects a failure.
     :rtype: flytekit.common.workflow.SdkWorkflow
     """
     wf = (cls or _common_workflow.SdkWorkflow)(

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         ]
     },
     install_requires=[
-        "flyteidl>=0.17.32,<1.0.0",
+        "flyteidl>=0.17.33,<1.0.0",
         "click>=6.6,<8.0",
         "croniter>=0.3.20,<4.0.0",
         "deprecated>=1.0,<2.0",

--- a/tests/flytekit/common/workflows/failing_workflows.py
+++ b/tests/flytekit/common/workflows/failing_workflows.py
@@ -1,0 +1,27 @@
+from __future__ import absolute_import, division, print_function
+
+from flytekit.sdk import tasks as _tasks, workflow as _workflow
+from flytekit.sdk.tasks import python_task
+from flytekit.sdk.types import Types as _Types
+from flytekit.sdk.workflow import workflow_class, Input, Output
+from flytekit.models.core.workflow import WorkflowMetadata
+
+
+@python_task
+def div_zero(wf_params):
+    return 5 / 0
+
+
+@workflow_class(on_failure=WorkflowMetadata.OnFailurePolicy.FAIL_AFTER_EXECUTABLE_NODES_COMPLETE)
+class FailingWorkflowWithRunToCompletion(object):
+    """
+    [start] ->  [first_layer] -> [second_layer]   ->  [end]
+            \\_  [first_layer_2]                      _/
+    """
+
+    first_layer = div_zero()
+    first_layer_2 = div_zero()
+    second_layer = div_zero()
+
+    # This forces second_layer node to run after first layer
+    first_layer >> second_layer

--- a/tests/flytekit/unit/models/core/test_workflow.py
+++ b/tests/flytekit/unit/models/core/test_workflow.py
@@ -94,6 +94,13 @@ def test_workflow_metadata_queuing_budget():
     obj2 = _workflow.WorkflowMetadata.from_flyte_idl(obj.to_flyte_idl())
     assert obj == obj2
 
+def test_workflow_metadata_failure_policy():
+    obj = _workflow.WorkflowMetadata(on_failure=_workflow.WorkflowMetadata.OnFailurePolicy.FAIL_AFTER_EXECUTABLE_NODES_COMPLETE)
+    obj2 = _workflow.WorkflowMetadata.from_flyte_idl(obj.to_flyte_idl())
+    assert obj == obj2
+    assert obj.on_failure == _workflow.WorkflowMetadata.OnFailurePolicy.FAIL_AFTER_EXECUTABLE_NODES_COMPLETE
+    assert obj2.on_failure == _workflow.WorkflowMetadata.OnFailurePolicy.FAIL_AFTER_EXECUTABLE_NODES_COMPLETE
+
 def test_workflow_metadata():
     obj = _workflow.WorkflowMetadata()
     obj2 = _workflow.WorkflowMetadata.from_flyte_idl(obj.to_flyte_idl())


### PR DESCRIPTION
# TL;DR
Add Failure Policy as an attribute of the workflow object.

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Complete description
```
@workflow_class(on_failure=WorkflowMetadata.OnFailurePolicy.FAIL_AFTER_EXECUTABLE_NODES_COMPLETE)
class FailingWorkflowWithRunToCompletion(object):
    """
    [start] ->  [first_layer] -> [second_layer]   ->  [end]
            \_  [first_layer_2]                      _/
    """

    first_layer = div_zero()
    first_layer_2 = div_zero()
    second_layer = div_zero()

    # This forces second_layer node to run after first layer
    first_layer >> second_layer
```

## Tracking Issue
https://github.com/lyft/flyte/issues/191