### PR TITLE
Bump version to 0.9.1

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 import flytekit.plugins
 
-__version__ = '0.9.0b2'
+__version__ = '0.9.1'


### PR DESCRIPTION
# TL;DR
Bump version to 0.9.1 to make the OnFailurePolicy available when FlyteKit's upgraded.

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Tracking Issue
lyft/flyte#191