### PR TITLE
bump up version for python-dateutil to support lyftlearnclient upgrade and enable great expectations latest version

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 import flytekit.plugins
 
-__version__ = '0.9.1'
+__version__ = '0.9.2'

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "croniter>=0.3.20,<4.0.0",
         "deprecated>=1.0,<2.0",
         "boto3>=1.4.4,<2.0",
-        "python-dateutil<2.8.1,>=2.1",
+        "python-dateutil<=2.8.1,>=2.1",
         "grpcio>=1.3.0,<2.0",
         "protobuf>=3.6.1,<4",
         "pytimeparse>=1.1.8,<2.0.0",


### PR DESCRIPTION
Following the discussion from https://github.com/lyft/lyftlearnclient/pull/595 bumping up the version for `python-dateutil`.

STEP 2: [FAILED] `control run piptools.compile lyftlearnclient` There is a clash on `python-dateutil`. `GE` expects `python-dateutil>=2.8.1` but `flytekit` expects `python-dateutil<2.8.1` as from here https://github.com/lyft/flytekit/blob/8eb27ec61771f44bb25614401377b2f70b2c565c/setup.py#L38 There is no later version of `flytekit`.