### PR TITLE
Use to_flyte_literal_type() when comparing schema columns

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 import flytekit.plugins
 
-__version__ = '0.9.3'
+__version__ = '0.9.4'

--- a/flytekit/common/types/impl/schema.py
+++ b/flytekit/common/types/impl/schema.py
@@ -947,7 +947,7 @@ class Schema(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _literal_models.Sch
                         additional_msg="Cannot cast because a required column '{}' was not found.".format(k),
                         received_value=self
                     )
-                if v != self.type.sdk_columns[k]:
+                if v.to_flyte_literal_type() != self.type.sdk_columns[k].to_flyte_literal_type():
                     raise _user_exceptions.FlyteTypeException(
                         self.type.sdk_columns[k],
                         v,

--- a/flytekit/common/types/impl/schema.py
+++ b/flytekit/common/types/impl/schema.py
@@ -947,7 +947,8 @@ class Schema(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _literal_models.Sch
                         additional_msg="Cannot cast because a required column '{}' was not found.".format(k),
                         received_value=self
                     )
-                if v.to_flyte_literal_type() != self.type.sdk_columns[k].to_flyte_literal_type():
+                if not isinstance(v, _base_sdk_types.FlyteSdkType) or \
+                        v.to_flyte_literal_type() != self.type.sdk_columns[k].to_flyte_literal_type():
                     raise _user_exceptions.FlyteTypeException(
                         self.type.sdk_columns[k],
                         v,

--- a/tests/flytekit/unit/common_tests/types/test_schema.py
+++ b/tests/flytekit/unit/common_tests/types/test_schema.py
@@ -52,3 +52,20 @@ def test_typed_schema():
         assert len(b.type.columns) == len(_ALL_COLUMN_TYPES)
         assert list(b.type.sdk_columns.items()) == _ALL_COLUMN_TYPES
         assert b.remote_location.startswith(t.name)
+
+
+# Ensures that subclassing types works inside a schema.
+def test_casting():
+    class MyDateTime(primitives.Datetime):
+        ...
+
+    with test_utils.LocalTestFileSystem() as t:
+        test_columns_1 = [('altered', MyDateTime)]
+        test_columns_2 = [('altered', primitives.Datetime)]
+
+        instantiator_1 = schema.schema_instantiator(test_columns_1)
+        a = instantiator_1()
+
+        instantiator_2 = schema.schema_instantiator(test_columns_2)
+
+        a.cast_to(instantiator_2._schema_type)


### PR DESCRIPTION
# TL;DR
A user internally wanted to subclass one of our primitive types, and then created a separate type engine, and used said engine to resolve types.  However, since the Datetime primitive type was subclassed, the comparison failed.


## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
This relegates the comparison to a common denominator, namely the Flyte literal type object.

## Tracking Issue
Internal issue only

## Follow-up issue
NA
