### PR TITLE
Fix insecure flag

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 import flytekit.plugins
 
-__version__ = '0.10.4'
+__version__ = '0.10.5'


### PR DESCRIPTION
# TL;DR
It appears my previous [attempt](https://github.com/lyft/flytekit/pull/73/files) at fixing this failed.  I think now everything is actually fixed.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
it appears that flags operate like toggles. If both the default is true and the flag is passed in the command, they negate each other and it's as if it's not passed.

Tested with:
* `-i` right after flyte-cli
* `-i` after the subcommand
* without the `-i` flag at all,

while the config file had
* "insecure=True"
* "insecure=False"
* insecure not specified.

Also for flags, there is no difference between a required one and a not-required one it seems.

## Tracking Issue
NA

## Follow-up issue
NA
