### PR TITLE
Prefer the URL used to create the client object instead of configuration

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 import flytekit.plugins
 
-__version__ = '0.10.5'
+__version__ = '0.10.6'

--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -26,8 +26,8 @@ def _refresh_credentials_standard(flyte_client):
     :return:
     """
 
-    _credentials_access.get_client().refresh_access_token()
-    flyte_client.set_access_token(_credentials_access.get_client().credentials.access_token)
+    _credentials_access.get_client(flyte_client.url).refresh_access_token()
+    flyte_client.set_access_token(_credentials_access.get_client(flyte_client.url).credentials.access_token)
 
 
 def _refresh_credentials_basic(flyte_client):
@@ -40,7 +40,7 @@ def _refresh_credentials_basic(flyte_client):
     :param flyte_client: RawSynchronousFlyteClient
     :return:
     """
-    auth_endpoints = _credentials_access.get_authorization_endpoints()
+    auth_endpoints = _credentials_access.get_authorization_endpoints(flyte_client.url)
     token_endpoint = auth_endpoints.token_endpoint
     client_secret = _basic_auth.get_secret()
     _logging.debug('Basic authorization flow with client id {} scope {}'.format(_CLIENT_ID.get(), _SCOPE.get()))
@@ -130,6 +130,7 @@ class RawSynchronousFlyteClient(object):
             service-side of the RPC.
         """
         self._channel = None
+        self._url = url
 
         if insecure:
             self._channel = _insecure_channel(url, options=list((options or {}).items()))
@@ -143,6 +144,10 @@ class RawSynchronousFlyteClient(object):
         self._metadata = None
         if _AUTH.get():
             self.force_auth_flow()
+
+    @property
+    def url(self) -> str:
+        return self._url
 
     def set_access_token(self, access_token):
         # Always set the header to lower-case regardless of what the config is. The grpc libraries that Admin uses

--- a/flytekit/clis/auth/credentials.py
+++ b/flytekit/clis/auth/credentials.py
@@ -11,10 +11,8 @@ from flytekit.configuration.creds import (
 )
 from flytekit.configuration.platform import URL as _URL, INSECURE as _INSECURE, HTTP_URL as _HTTP_URL
 
-try:  # Python 3
-    import urllib.parse as _urlparse
-except ImportError:  # Python 2
-    import urlparse as _urlparse
+
+import urllib.parse as _urlparse
 
 # Default, well known-URI string used for fetching JSON metadata. See https://tools.ietf.org/html/rfc8414#section-3.
 discovery_endpoint_path = "./.well-known/oauth-authorization-server"
@@ -43,11 +41,11 @@ def _get_discovery_endpoint(http_config_val, platform_url_val, insecure_val):
 _authorization_client = None
 
 
-def get_client():
+def get_client(flyte_client_url):
     global _authorization_client
     if _authorization_client is not None and not _authorization_client.expired:
         return _authorization_client
-    authorization_endpoints = get_authorization_endpoints()
+    authorization_endpoints = get_authorization_endpoints(flyte_client_url)
 
     _authorization_client =\
         _AuthorizationClient(redirect_uri=_REDIRECT_URI.get(), client_id=_CLIENT_ID.get(),
@@ -56,7 +54,7 @@ def get_client():
     return _authorization_client
 
 
-def get_authorization_endpoints():
-    discovery_endpoint = _get_discovery_endpoint(_HTTP_URL.get(), _URL.get(), _INSECURE.get())
+def get_authorization_endpoints(flyte_client_url):
+    discovery_endpoint = _get_discovery_endpoint(_HTTP_URL.get(), flyte_client_url or _URL.get(), _INSECURE.get())
     discovery_client = _DiscoveryClient(discovery_url=discovery_endpoint)
     return discovery_client.get_authorization_endpoints()

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -454,7 +454,7 @@ _optional_urns_only_option = _click.option(
     help="[Optional] Set the flag if you want to list the urns only"
 )
 _project_identifier_option = _click.option(
-    '--identifier',
+    '-p', '--identifier',
     required=True,
     type=str,
     help="Unique identifier for the project."

--- a/tests/flytekit/unit/clients/test_raw.py
+++ b/tests/flytekit/unit/clients/test_raw.py
@@ -31,5 +31,7 @@ def test_refresh_credentials_basic(mock_credentials_access, mock_requests):
     os.environ[_CREDENTIALS_SECRET.env_var] = "asdf12345"
 
     mock_client = mock.MagicMock()
+    mock_client.url.return_value = 'flyte.corp.net'
     _refresh_credentials_basic(mock_client)
     mock_client.set_access_token.assert_called_with('abc')
+    mock_credentials_access.get_authorization_endpoints.assert_called_with(mock_client.url)

--- a/tests/flytekit/unit/clients/test_raw.py
+++ b/tests/flytekit/unit/clients/test_raw.py
@@ -31,7 +31,7 @@ def test_refresh_credentials_basic(mock_credentials_access, mock_requests):
     os.environ[_CREDENTIALS_SECRET.env_var] = "asdf12345"
 
     mock_client = mock.MagicMock()
-    mock_client.url.return_value = 'flyte.corp.net'
+    mock_client.url.return_value = 'flyte.localhost'
     _refresh_credentials_basic(mock_client)
     mock_client.set_access_token.assert_called_with('abc')
     mock_credentials_access.get_authorization_endpoints.assert_called_with(mock_client.url)


### PR DESCRIPTION
# TL;DR
When the `RawSynchronousFlyteClient` is created, it's given a host.  We should prefer to use this instead of retrieving from configuration again.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
Save the url passed into the client instead and when it comes time to get the Admin endpoints, use it first.  Configuration fallback has been left in there in case we make the client url optional down the road.

## Tracking Issue
https://github.com/lyft/flyte/issues/368

## Follow-up issue
NA
