### PR TITLE
Add a --watch argument to execute-launch-plan command and add a watch-execution command

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 import flytekit.plugins
 
-__version__ = '0.10.6b0'
+__version__ = '0.10.6'

--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 import flytekit.plugins
 
-__version__ = '0.10.6'
+__version__ = '0.10.7'

--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 import flytekit.plugins
 
-__version__ = '0.10.5'
+__version__ = '0.10.6b0'

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -1087,9 +1087,8 @@ def update_launch_plan(state, host, insecure, urn=None):
 @_principal_option
 @_verbose_option
 @_watch_option
-@_optional_urns_only_option
 @_click.argument('lp_args', nargs=-1, type=_click.UNPROCESSED)
-def execute_launch_plan(project, domain, name, host, insecure, urn, principal, verbose, watch, urns_only, lp_args):
+def execute_launch_plan(project, domain, name, host, insecure, urn, principal, verbose, watch, lp_args):
     """
     Kick off a launch plan. Note that the {project, domain, name} specified in the command line
     will be for the execution.  The project/domain for the launch plan are specified in the urn.
@@ -1104,10 +1103,7 @@ def execute_launch_plan(project, domain, name, host, insecure, urn, principal, v
     These arguments are then collected, and passed into the `lp_args` variable as a Tuple[Text].
     Users should use the get-launch-plan command to ascertain the names of inputs to use.
     """
-    if not urns_only:
-        _welcome_message()
-    else:
-        verbose = False
+    _welcome_message()
 
     with _platform_config.URL.get_patcher(host), _platform_config.INSECURE.get_patcher(_tt(insecure)):
         lp_id = _identifier.Identifier.from_python_std(urn)
@@ -1118,15 +1114,10 @@ def execute_launch_plan(project, domain, name, host, insecure, urn, principal, v
         # TODO: Implement label overrides
         # TODO: Implement annotation overrides
         execution = lp.launch_with_literals(project, domain, inputs, name=name)
-        if not urns_only:
-            _click.secho("Launched execution: {}".format(_tt(execution.id)), fg='blue')
-            _click.echo("")
-        else:
-            _click.secho("{}".format(_tt(execution.id)))
+        _click.secho("Launched execution: {}".format(_tt(execution.id)), fg='blue')
+        _click.echo("")
 
         if watch is True:
-            if not urns_only:
-                _click.echo("Watching the execution {} until completion ...".format(_tt(execution.id)))
             execution.wait_for_completion()
 
 

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -1146,7 +1146,7 @@ def watch_execution(host, insecure, urn):
     Wait for an execution to complete.
 
     e.g.
-        $ flyte-cli -h localhost:30081 wait-for-completion -u ex:flyteexamples:development:abc123
+        $ flyte-cli -h localhost:30081 watch-execution -u ex:flyteexamples:development:abc123
     """
     _welcome_message()
 


### PR DESCRIPTION
# TL;DR
Adding a command `execute-launch-plan-and-wait`, by using which users kick off an execution and enforce a wait for the completion of the execution. This can be useful for kicking off workflows as tests in CI.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description


## Tracking Issue


## Follow-up issue
_NA_

