### PR TITLE
Add support for parallelism with gsutil command in GCSProxy

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 import flytekit.plugins
 
-__version__ = '0.10.7'
+__version__ = "0.10.8"

--- a/flytekit/configuration/gcp.py
+++ b/flytekit/configuration/gcp.py
@@ -2,4 +2,7 @@ from __future__ import absolute_import
 
 from flytekit.configuration import common as _config_common
 
-GCS_PREFIX = _config_common.FlyteRequiredStringConfigurationEntry('gcp', 'gcs_prefix')
+GCS_PREFIX = _config_common.FlyteRequiredStringConfigurationEntry("gcp", "gcs_prefix")
+GSUTIL_PARALLELISM = _config_common.FlyteBoolConfigurationEntry(
+    "gcp", "gsutil_parallelism", default=False
+)

--- a/flytekit/configuration/gcp.py
+++ b/flytekit/configuration/gcp.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from flytekit.configuration import common as _config_common
 
-GCS_PREFIX = _config_common.FlyteRequiredStringConfigurationEntry("gcp", "gcs_prefix")
+GCS_PREFIX = _config_common.FlyteRequiredStringConfigurationEntry('gcp', 'gcs_prefix')
 GSUTIL_PARALLELISM = _config_common.FlyteBoolConfigurationEntry(
-    "gcp", "gsutil_parallelism", default=False
+    'gcp', 'gsutil_parallelism', default=False
 )

--- a/flytekit/configuration/gcp.py
+++ b/flytekit/configuration/gcp.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from flytekit.configuration import common as _config_common
 
-GCS_PREFIX = _config_common.FlyteRequiredStringConfigurationEntry('gcp', 'gcs_prefix')
+GCS_PREFIX = _config_common.FlyteRequiredStringConfigurationEntry("gcp", "gcs_prefix")
 GSUTIL_PARALLELISM = _config_common.FlyteBoolConfigurationEntry(
-    'gcp', 'gsutil_parallelism', default=False
+    "gcp", "gsutil_parallelism", default=False
 )

--- a/flytekit/interfaces/data/gcs/gcs_proxy.py
+++ b/flytekit/interfaces/data/gcs/gcs_proxy.py
@@ -35,7 +35,7 @@ class GCSProxy(_common_data.DataProxy):
         Make sure that the `gsutil` cli is present
         """
         if not _which(GCSProxy._GS_UTIL_CLI):
-            raise _FlyteUserException('gsutil (gcloud cli) not found! Please install.')
+            raise _FlyteUserException("gsutil (gcloud cli) not found! Please install.")
 
     @staticmethod
     def _maybe_with_gsutil_parallelism(*gsutil_args):

--- a/flytekit/interfaces/data/gcs/gcs_proxy.py
+++ b/flytekit/interfaces/data/gcs/gcs_proxy.py
@@ -32,10 +32,25 @@ class GCSProxy(_common_data.DataProxy):
     @staticmethod
     def _check_binary():
         """
-        Make sure that the AWS cli is present
+        Make sure that the `gsutil` cli is present
         """
         if not _which(GCSProxy._GS_UTIL_CLI):
-            raise _FlyteUserException('gsutil (gcloud cli) not found at Please install.')
+            raise _FlyteUserException('gsutil (gcloud cli) not found! Please install.')
+
+    @staticmethod
+    def _maybe_with_gsutil_parallelism(self, *gsutil_args):
+        """
+        Check if we should run `gsutil` with the `-m` flag that enables
+        parallelism via multiple threads/processes. Additional tweaking of
+        this behavior can be achieved via the .boto configuration file. See:
+        https://cloud.google.com/storage/docs/boto-gsutil
+        """
+        cmd = [GCSProxy._GS_UTIL_CLI]
+        if _gcp_config.GSUTIL_PARALLELISM:
+            cmd.append("-m")
+        cmd.extend(gsutil_args)
+
+        return cmd
 
     def exists(self, remote_path):
         """
@@ -64,7 +79,7 @@ class GCSProxy(_common_data.DataProxy):
         if not remote_path.startswith("gs://"):
             raise ValueError("Not an GS Key. Please use FQN (GS ARN) of the format gs://...")
 
-        cmd = [GCSProxy._GS_UTIL_CLI, "cp", "-r", _amend_path(remote_path), local_path]
+        cmd = self._maybe_with_gsutil_parallelism("cp", "-r", _amend_path(remote_path), local_path)
         return _update_cmd_config_and_execute(cmd)
 
     def download(self, remote_path, local_path):
@@ -76,7 +91,8 @@ class GCSProxy(_common_data.DataProxy):
             raise ValueError("Not an GS Key. Please use FQN (GS ARN) of the format gs://...")
 
         GCSProxy._check_binary()
-        cmd = [GCSProxy._GS_UTIL_CLI, "cp", remote_path, local_path]
+
+        cmd = self._maybe_with_gsutil_parallelism("cp", remote_path, local_path)
         return _update_cmd_config_and_execute(cmd)
 
     def upload(self, file_path, to_path):
@@ -86,8 +102,7 @@ class GCSProxy(_common_data.DataProxy):
         """
         GCSProxy._check_binary()
 
-        cmd = [GCSProxy._GS_UTIL_CLI, "cp", file_path, to_path]
-
+        cmd = self._maybe_with_gsutil_parallelism("cp", file_path, to_path)
         return _update_cmd_config_and_execute(cmd)
 
     def upload_directory(self, local_path, remote_path):
@@ -100,11 +115,12 @@ class GCSProxy(_common_data.DataProxy):
 
         GCSProxy._check_binary()
 
-        cmd = [GCSProxy._GS_UTIL_CLI,
-               "cp",
-               "-r",
-               _amend_path(local_path),
-               remote_path if remote_path.endswith("/") else remote_path + "/"]
+        cmd = self._maybe_with_gsutil_parallelism(
+           "cp",
+           "-r",
+           _amend_path(local_path),
+           remote_path if remote_path.endswith("/") else remote_path + "/"
+        )
         return _update_cmd_config_and_execute(cmd)
 
     def get_random_path(self):

--- a/flytekit/interfaces/data/gcs/gcs_proxy.py
+++ b/flytekit/interfaces/data/gcs/gcs_proxy.py
@@ -38,7 +38,7 @@ class GCSProxy(_common_data.DataProxy):
             raise _FlyteUserException('gsutil (gcloud cli) not found! Please install.')
 
     @staticmethod
-    def _maybe_with_gsutil_parallelism(self, *gsutil_args):
+    def _maybe_with_gsutil_parallelism(*gsutil_args):
         """
         Check if we should run `gsutil` with the `-m` flag that enables
         parallelism via multiple threads/processes. Additional tweaking of

--- a/flytekit/interfaces/data/gcs/gcs_proxy.py
+++ b/flytekit/interfaces/data/gcs/gcs_proxy.py
@@ -46,7 +46,7 @@ class GCSProxy(_common_data.DataProxy):
         https://cloud.google.com/storage/docs/boto-gsutil
         """
         cmd = [GCSProxy._GS_UTIL_CLI]
-        if _gcp_config.GSUTIL_PARALLELISM:
+        if _gcp_config.GSUTIL_PARALLELISM.get():
             cmd.append("-m")
         cmd.extend(gsutil_args)
 

--- a/tests/flytekit/unit/interfaces/data/gcs/test_gcs_proxy.py
+++ b/tests/flytekit/unit/interfaces/data/gcs/test_gcs_proxy.py
@@ -15,6 +15,13 @@ def mock_update_cmd_config_and_execute():
 
 
 @_pytest.fixture
+def gsutil_parallelism():
+    p = _mock.patch("flytekit.configuration.gcp.GSUTIL_PARALLELISM.get", return_value=True)
+    yield p.start()
+    p.stop()
+
+
+@_pytest.fixture
 def gcs_proxy():
     return _gcs_proxy.GCSProxy()
 
@@ -44,4 +51,24 @@ def test_upload_directory_padding_slash_for_remote_path(
     gcs_proxy.upload_directory(local_path, remote_path)
     mock_update_cmd_config_and_execute.assert_called_once_with(
         ["gsutil", "cp", "-r", local_path, remote_path + "/"]
+    )
+
+
+def test_download_with_parallelism(
+    mock_update_cmd_config_and_execute, gsutil_parallelism, gcs_proxy
+):
+    local_path, remote_path = "/foo", "gs://bar/0/"
+    gcs_proxy.download(remote_path, local_path)
+    mock_update_cmd_config_and_execute.assert_called_once_with(
+        ["gsutil", "-m", "cp", remote_path, local_path]
+    )
+
+
+def test_upload_directory_with_parallelism(
+    mock_update_cmd_config_and_execute, gsutil_parallelism, gcs_proxy
+):
+    local_path, remote_path = "/foo/*", "gs://bar/0/"
+    gcs_proxy.upload_directory(local_path, remote_path)
+    mock_update_cmd_config_and_execute.assert_called_once_with(
+        ["gsutil", "-m", "cp", "-r", local_path, remote_path]
     )

--- a/tests/flytekit/unit/interfaces/data/gcs/test_gcs_proxy.py
+++ b/tests/flytekit/unit/interfaces/data/gcs/test_gcs_proxy.py
@@ -54,6 +54,18 @@ def test_upload_directory_padding_slash_for_remote_path(
     )
 
 
+def test_maybe_with_gsutil_parallelism_disabled(gcs_proxy):
+    local_path, remote_path = "foo", "gs://bar/0/"
+    cmd = gcs_proxy._maybe_with_gsutil_parallelism("cp", local_path, remote_path)
+    assert cmd == ["gsutil", "cp", local_path, remote_path]
+
+
+def test_maybe_with_gsutil_parallelism_enabled(gsutil_parallelism, gcs_proxy):
+    local_path, remote_path = "foo", "gs://bar/0/"
+    cmd = gcs_proxy._maybe_with_gsutil_parallelism("cp", "-r", local_path, remote_path)
+    assert cmd == ["gsutil", "-m", "cp", "-r", local_path, remote_path]
+
+
 def test_download_with_parallelism(
     mock_update_cmd_config_and_execute, gsutil_parallelism, gcs_proxy
 ):


### PR DESCRIPTION
# TL;DR
Adds multiprocessing support to the GCS data proxy via the `-m` flag to `gsutil`. This can be turned on via the `gcp.gsutil_parallelism` configuration variable.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 We can achieve much better performance with `gsutil` with the `-m` flag that enables parallelism via multiple processes/threads. This will come in extremely handy when up/downloading a large number of files or just a few large files. See: https://medium.com/@duhroach/gcs-read-performance-of-large-files-bd53cfca4410.

I figured that the best way to enable this will be via the `[gcp]` configuration block: `gsutil_parallelism`. Further tweaking of the parallelism behavior can be achieved via the `.boto` config file: https://cloud.google.com/storage/docs/boto-gsutil

## Tracking Issue
https://github.com/lyft/flyte/issues/429

## Follow-up issue
_NA_
