### PR TITLE
Remove test breaking numpy 1.19

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 import flytekit.plugins
 
-__version__ = "0.10.8"
+__version__ = "0.10.9"

--- a/flytekit/common/types/impl/schema.py
+++ b/flytekit/common/types/impl/schema.py
@@ -190,8 +190,7 @@ class _SchemaReader(_SchemaIO):
         when using fastparquet as the underlying parquet engine.
 
         When using fastparquet, boolean columns containing None values will be promoted to float16 columns.
-        This behavior is inconsistent with what Pandas and Pyarrow does, which promote such columns
-        to object columns. This becomes problematic when users want to write the dataframe back into parquet
+        This becomes problematic when users want to write the dataframe back into parquet
         file because float16 (halffloat) is not a supported type in parquet spec. In this function, we detect
         such columns and do override the type promotion.
         """

--- a/tests/flytekit/unit/common_tests/types/impl/test_schema.py
+++ b/tests/flytekit/unit/common_tests/types/impl/test_schema.py
@@ -526,41 +526,13 @@ def test_normal_schema_read_with_fastparquet():
             _os.environ['PARQUET_ENGINE'] = original_engine
 
 
-def test_type_promoted_schema_read_with_fastparquet():
-    with _test_utils.LocalTestFileSystem():
-        a = _schema_impl.Schema.create_at_any_location(
-            schema_type=_schema_impl.SchemaType([('a', _primitives.Integer), ('b', _primitives.Boolean)])
-        )
-        with a as writer:
-            writer.write(_pd.DataFrame.from_dict({'a': [1, 2, 3, 4], 'b': [None, True, None, False]}))
-
-        import os as _os
-        original_engine = _os.getenv('PARQUET_ENGINE')
-        _os.environ['PARQUET_ENGINE'] = 'fastparquet'
-
-        b = _schema_impl.Schema.fetch(
-            a.remote_prefix,
-            schema_type=_schema_impl.SchemaType([]))
-
-        with b as reader:
-            df = reader.read()
-            assert df['a'].tolist() == [1, 2, 3, 4]
-            assert _pd.api.types.is_object_dtype(df.dtypes['b'])
-            assert df['b'].tolist() == [None, True, None, False]
-
-        if original_engine is None:
-            del _os.environ['PARQUET_ENGINE']
-        else:
-            _os.environ['PARQUET_ENGINE'] = original_engine
-
-
 def test_schema_read_consistency_between_two_engines():
     with _test_utils.LocalTestFileSystem():
         a = _schema_impl.Schema.create_at_any_location(
             schema_type=_schema_impl.SchemaType([('a', _primitives.Integer), ('b', _primitives.Boolean)])
         )
         with a as writer:
-            writer.write(_pd.DataFrame.from_dict({'a': [1, 2, 3, 4], 'b': [None, True, None, False]}))
+            writer.write(_pd.DataFrame.from_dict({'a': [1, 2, 3, 4], 'b': [True, True, True, False]}))
 
         import os as _os
         original_engine = _os.getenv('PARQUET_ENGINE')


### PR DESCRIPTION
# TL;DR
Basically if you `pip install numpy==1.18` this works.

```
python -m pytest -svv tests/flytekit/unit/common_tests/types/impl/test_schema.py::test_type_promoted_schema_read_with_fastparquet                                                                                  
```

If you `pip install numpy==1.19`

it fails.  Basically in 1.18 and earlier, if you declared a bool column and had Nones in the data, it would automatically promote the column to an object.  Starting with 1.19, they're no longer do this.  The 1.19 behavior makes more sense IMO, since this is how most typed languages work.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
Removed the offending test.

## Tracking Issue
https://github.com/lyft/flyte/issues/430

## Follow-up issue
In working on this, also discovered that the fastparquet test wasn't actually setting the fastparquet engine.  Doing so ended up failing the test though it might be a simple case of missing dependencies.  Created this issue to follow up later.
https://github.com/lyft/flyte/issues/433

