### PR TITLE
Fix Primitive.value returning None issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ pip install flytekit
 If `@spark_task` is to be used, one should install the `spark` plugin.
 
 ```bash
-pip install flytekit[spark] for Spark 2.4.x
-pip install flytekit[spark3] for Spark 3.x
+pip install "flytekit[spark]" for Spark 2.4.x
+pip install "flytekit[spark3]" for Spark 3.x
 ```
 
 #### Schema 
@@ -48,7 +48,7 @@ pip install flytekit[spark3] for Spark 3.x
 If `Types.Schema()` is to be used for computations involving large dataframes, one should install the `schema` extension.
 
 ```bash
-pip install flytekit[schema]
+pip install "flytekit[schema]"
 ```
 
 #### Sidecar
@@ -56,7 +56,7 @@ pip install flytekit[schema]
 If `@sidecar_task` is to be used, one should install the `sidecar` plugin.
 
 ```bash
-pip install flytekit[sidecar]
+pip install "flytekit[sidecar]"
 ```
 
 ### Pytorch
@@ -64,7 +64,7 @@ pip install flytekit[sidecar]
 If `@pytorch_task` is to be used, one should install the `pytorch` plugin.
 
 ```bash
-pip install flytekit[pytorch]
+pip install "flytekit[pytorch]"
 ```
 
 ### Full Installation
@@ -72,13 +72,13 @@ pip install flytekit[pytorch]
 To install all or multiple available plugins, one can specify them individually:
 
 ```bash
-pip install flytekit[sidecar,spark,schema]
+pip install "flytekit[sidecar,spark,schema]"
 ```
 
 Or install them with the `all` directive. `all` defaults to Spark 2.4.x currently.
 
 ```bash
-pip install flytekit[all]
+pip install "flytekit[all]"
 ```
 
 ## Testing
@@ -92,7 +92,7 @@ Flytekit is Python 2.7+ compatible, so when feasible, it is recommended to test 
 virtualenv ~/.virtualenvs/flytekit
 source ~/.virtualenvs/flytekit/bin/activate
 python -m pip install -r requirements.txt
-python -m pip install -U .[all]
+python -m pip install -U ".[all]"
 ```
 
 #### Execute

--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 import flytekit.plugins
 
-__version__ = "0.10.10"
+__version__ = "0.10.11"

--- a/flytekit/models/literals.py
+++ b/flytekit/models/literals.py
@@ -119,7 +119,9 @@ class Primitive(_common.FlyteIdlEntity):
         This returns whichever field is set.
         :rtype: T
         """
-        return self.integer or self.float_value or self.string_value or self.boolean or self.datetime or self.duration
+        for value in [self.integer, self.float_value, self.string_value, self.boolean, self.datetime, self.duration]:
+            if value is not None:
+                return value
 
     def to_flyte_idl(self):
         """

--- a/tests/flytekit/unit/models/test_literals.py
+++ b/tests/flytekit/unit/models/test_literals.py
@@ -55,6 +55,9 @@ def test_integer_primitive():
     assert obj2 != literals.Primitive(float_value=1.0)
     assert obj2 != literals.Primitive(string_value='abc')
 
+    obj3 = literals.Primitive(integer=0)
+    assert obj3.value == 0
+
     with pytest.raises(Exception):
         literals.Primitive(integer=1.0).to_flyte_idl()
 
@@ -90,6 +93,9 @@ def test_boolean_primitive():
     assert obj2 != literals.Primitive(duration=timedelta(minutes=1))
     assert obj2 != literals.Primitive(float_value=1.0)
     assert obj2 != literals.Primitive(string_value='abc')
+
+    obj3 = literals.Primitive(boolean=False)
+    assert obj3.value is False
 
     with pytest.raises(Exception):
         literals.Primitive(boolean=datetime.now()).to_flyte_idl()
@@ -201,6 +207,9 @@ def test_float_primitive():
     assert obj2 != literals.Primitive(float_value=0.0)
     assert obj2 != literals.Primitive(string_value='abc')
 
+    obj3 = literals.Primitive(float_value=0.0)
+    assert obj3.value == 0.0
+
     with pytest.raises(Exception):
         literals.Primitive(float_value='abc').to_flyte_idl()
 
@@ -236,6 +245,9 @@ def test_string_primitive():
     assert obj2 != literals.Primitive(duration=timedelta(minutes=1))
     assert obj2 != literals.Primitive(float_value=0.0)
     assert obj2 != literals.Primitive(string_value='bca')
+
+    obj3 = literals.Primitive(string_value="")
+    assert obj3.value == ""
 
     with pytest.raises(Exception):
         literals.Primitive(string_value=1.0).to_flyte_idl()


### PR DESCRIPTION
# TL;DR
There's a bug in the `value` function where if a `0`, `""`, `0.0`, or `False` is set as the Primitive, then the function would always return `None`.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue
