### PR TITLE
Sagemaker is only available in v0.18.0 onwards.

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 import flytekit.plugins
 
-__version__ = '0.11.3'
+__version__ = '0.11.4'

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         ]
     },
     install_requires=[
-        "flyteidl>=0.17.34,<1.0.0",
+        "flyteidl>=0.18.1,<1.0.0",
         "click>=6.6,<8.0",
         "croniter>=0.3.20,<4.0.0",
         "deprecated>=1.0,<2.0",


### PR DESCRIPTION
# TL;DR
If you upgrade flytekit, flyteidl will not be upgraded and this is required for Sagemaker

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
NA
