### PR TITLE
Add dynamic sidecar tasks

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 import flytekit.plugins
 
-__version__ = '0.11.5'
+__version__ = '0.11.6'

--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 import flytekit.plugins
 
-__version__ = '0.11.4'
+__version__ = '0.11.5'

--- a/flytekit/common/tasks/sdk_dynamic.py
+++ b/flytekit/common/tasks/sdk_dynamic.py
@@ -60,6 +60,11 @@ class SdkDynamicTaskMixin(object):
     """
 
     def __init__(self, allowed_failure_ratio, max_concurrency):
+        """
+        :param float allowed_failure_ratio:
+        :param int max_concurrency:
+        """
+
         # These will only appear in the generated futures
         self._allowed_failure_ratio = allowed_failure_ratio
         self._max_concurrency = max_concurrency

--- a/flytekit/common/tasks/sdk_dynamic.py
+++ b/flytekit/common/tasks/sdk_dynamic.py
@@ -52,6 +52,13 @@ def _append_node(generated_files, node, nodes, sub_task_node):
 
 
 class SdkDynamicTaskMixin(object):
+
+    """
+    This mixin implements logic for building a task that executes
+    parent-child tasks in Python code.
+
+    """
+
     def __init__(self, allowed_failure_ratio, max_concurrency):
         # These will only appear in the generated futures
         self._allowed_failure_ratio = allowed_failure_ratio
@@ -251,12 +258,11 @@ class SdkDynamicTaskMixin(object):
 
 
 class SdkDynamicTask(SdkDynamicTaskMixin, _sdk_runnable.SdkRunnableTask, metaclass=_sdk_bases.ExtendedSdkType):
-    """
-    This class includes the additional logic for building a task that executes parent-child tasks in Python code.  It
-    has even more validation checks to ensure proper behavior than it's superclasses.
 
-    Since an SdkDynamicTask is assumed to run by hooking into Python code, we will provide additional shortcuts and
-    methods on this object.
+    """
+    This class includes the additional logic for building a task that executes
+    parent-child tasks in Python code.
+
     """
 
     def __init__(

--- a/flytekit/common/tasks/sdk_dynamic.py
+++ b/flytekit/common/tasks/sdk_dynamic.py
@@ -109,7 +109,7 @@ class SdkDynamicTaskMixin:
         # before calling user code
         inputs_dict.update(outputs_dict)
         yielded_sub_tasks = [sub_task for sub_task in
-                             super(SdkDynamicTask, self)._execute_user_code(context, inputs_dict) or []]
+                             self._execute_user_code(context, inputs_dict) or []]
 
         upstream_nodes = list()
         output_bindings = [_literal_models.Binding(var=name, binding=_interface.BindingData.from_python_std(

--- a/flytekit/common/tasks/sdk_dynamic.py
+++ b/flytekit/common/tasks/sdk_dynamic.py
@@ -51,65 +51,8 @@ def _append_node(generated_files, node, nodes, sub_task_node):
                   sub_task_node.inputs})
 
 
-class SdkDynamicTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _sdk_runnable.SdkRunnableTask)):
-    """
-    This class includes the additional logic for building a task that executes parent-child tasks in Python code.  It
-    has even more validation checks to ensure proper behavior than it's superclasses.
-
-    Since an SdkDynamicTask is assumed to run by hooking into Python code, we will provide additional shortcuts and
-    methods on this object.
-    """
-
-    def __init__(
-            self,
-            task_function,
-            task_type,
-            discovery_version,
-            retries,
-            interruptible,
-            deprecated,
-            storage_request,
-            cpu_request,
-            gpu_request,
-            memory_request,
-            storage_limit,
-            cpu_limit,
-            gpu_limit,
-            memory_limit,
-            discoverable,
-            timeout,
-            allowed_failure_ratio,
-            max_concurrency,
-            environment,
-            custom
-    ):
-        """
-        :param task_function: Function container user code.  This will be executed via the SDK's engine.
-        :param Text task_type: string describing the task type
-        :param Text discovery_version: string describing the version for task discovery purposes
-        :param int retries: Number of retries to attempt
-        :param bool interruptible: Whether or not task is interruptible
-        :param Text deprecated:
-        :param Text storage_request:
-        :param Text cpu_request:
-        :param Text gpu_request:
-        :param Text memory_request:
-        :param Text storage_limit:
-        :param Text cpu_limit:
-        :param Text gpu_limit:
-        :param Text memory_limit:
-        :param bool discoverable:
-        :param datetime.timedelta timeout:
-        :param float allowed_failure_ratio:
-        :param int max_concurrency:
-        :param dict[Text, Text] environment:
-        :param dict[Text, T] custom:
-        """
-        super(SdkDynamicTask, self).__init__(
-            task_function, task_type, discovery_version, retries, interruptible, deprecated,
-            storage_request, cpu_request, gpu_request, memory_request, storage_limit,
-            cpu_limit, gpu_limit, memory_limit, discoverable, timeout, environment, custom)
-
+class SdkDynamicTaskMixin:
+    def __init__(self, allowed_failure_ratio, max_concurrency):
         # These will only appear in the generated futures
         self._allowed_failure_ratio = allowed_failure_ratio
         self._max_concurrency = max_concurrency
@@ -305,3 +248,65 @@ class SdkDynamicTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _sdk_runnab
             })
 
             return generated_files
+
+
+class SdkDynamicTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, SdkDynamicTaskMixin, _sdk_runnable.SdkRunnableTask)):
+    """
+    This class includes the additional logic for building a task that executes parent-child tasks in Python code.  It
+    has even more validation checks to ensure proper behavior than it's superclasses.
+
+    Since an SdkDynamicTask is assumed to run by hooking into Python code, we will provide additional shortcuts and
+    methods on this object.
+    """
+
+    def __init__(
+            self,
+            task_function,
+            task_type,
+            discovery_version,
+            retries,
+            interruptible,
+            deprecated,
+            storage_request,
+            cpu_request,
+            gpu_request,
+            memory_request,
+            storage_limit,
+            cpu_limit,
+            gpu_limit,
+            memory_limit,
+            discoverable,
+            timeout,
+            allowed_failure_ratio,
+            max_concurrency,
+            environment,
+            custom
+    ):
+        """
+        :param task_function: Function container user code.  This will be executed via the SDK's engine.
+        :param Text task_type: string describing the task type
+        :param Text discovery_version: string describing the version for task discovery purposes
+        :param int retries: Number of retries to attempt
+        :param bool interruptible: Whether or not task is interruptible
+        :param Text deprecated:
+        :param Text storage_request:
+        :param Text cpu_request:
+        :param Text gpu_request:
+        :param Text memory_request:
+        :param Text storage_limit:
+        :param Text cpu_limit:
+        :param Text gpu_limit:
+        :param Text memory_limit:
+        :param bool discoverable:
+        :param datetime.timedelta timeout:
+        :param float allowed_failure_ratio:
+        :param int max_concurrency:
+        :param dict[Text, Text] environment:
+        :param dict[Text, T] custom:
+        """
+        _sdk_runnable.SdkRunnableTask.__init__(
+            self, task_function, task_type, discovery_version, retries, interruptible, deprecated,
+            storage_request, cpu_request, gpu_request, memory_request, storage_limit,
+            cpu_limit, gpu_limit, memory_limit, discoverable, timeout, environment, custom)
+
+        SdkDynamicTaskMixin.__init__(self, allowed_failure_ratio, max_concurrency)

--- a/flytekit/common/tasks/sdk_dynamic.py
+++ b/flytekit/common/tasks/sdk_dynamic.py
@@ -51,7 +51,7 @@ def _append_node(generated_files, node, nodes, sub_task_node):
                   sub_task_node.inputs})
 
 
-class SdkDynamicTaskMixin:
+class SdkDynamicTaskMixin(object):
     def __init__(self, allowed_failure_ratio, max_concurrency):
         # These will only appear in the generated futures
         self._allowed_failure_ratio = allowed_failure_ratio
@@ -250,7 +250,7 @@ class SdkDynamicTaskMixin:
             return generated_files
 
 
-class SdkDynamicTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, SdkDynamicTaskMixin, _sdk_runnable.SdkRunnableTask)):
+class SdkDynamicTask(SdkDynamicTaskMixin, _sdk_runnable.SdkRunnableTask, metaclass=_sdk_bases.ExtendedSdkType):
     """
     This class includes the additional logic for building a task that executes parent-child tasks in Python code.  It
     has even more validation checks to ensure proper behavior than it's superclasses.

--- a/flytekit/common/tasks/sidecar_task.py
+++ b/flytekit/common/tasks/sidecar_task.py
@@ -5,6 +5,7 @@ import six as _six
 from flyteidl.core import tasks_pb2 as _core_task
 
 from flytekit.common.exceptions import user as _user_exceptions
+from flytekit.common.tasks import sdk_dynamic as _sdk_dynamic
 from flytekit.common.tasks import sdk_runnable as _sdk_runnable
 from flytekit.common import sdk_bases as _sdk_bases
 
@@ -138,3 +139,67 @@ class SdkSidecarTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _sdk_runnab
         ).to_flyte_idl()
 
         self.assign_custom_and_return(_MessageToDict(sidecar_job_plugin))
+
+
+class SdkDynamicSidecarTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _sdk_dynamic.SdkDynamicTaskMixin, _sdk_runnable.SdkRunnableTask)):
+
+    """
+    This class includes the additional logic for building a task that executes as a Sidecar Job.
+
+    """
+
+    def __init__(self,
+                 task_function,
+                 task_type,
+                 discovery_version,
+                 retries,
+                 interruptible,
+                 deprecated,
+                 storage_request,
+                 cpu_request,
+                 gpu_request,
+                 memory_request,
+                 storage_limit,
+                 cpu_limit,
+                 gpu_limit,
+                 memory_limit,
+                 discoverable,
+                 timeout,
+                 allowed_failure_ratio,
+                 max_concurrency,
+                 environment,
+                 pod_spec=None,
+                 primary_container_name=None):
+        """
+        :param _sdk_runnable.SdkRunnableTask sdk_runnable_task:
+        :param generated_pb2.PodSpec pod_spec:
+        :param Text primary_container_name:
+        :raises: flytekit.common.exceptions.user.FlyteValidationException
+        """
+        if not pod_spec:
+            raise _user_exceptions.FlyteValidationException("A pod spec cannot be undefined")
+        if not primary_container_name:
+            raise _user_exceptions.FlyteValidationException("A primary container name cannot be undefined")
+
+        SdkSidecarTask.__init__(
+            self,
+            task_function,
+            task_type,
+            discovery_version,
+            retries,
+            interruptible,
+            deprecated,
+            storage_request,
+            cpu_request,
+            gpu_request,
+            memory_request,
+            storage_limit,
+            cpu_limit,
+            gpu_limit,
+            memory_limit,
+            discoverable,
+            timeout,
+            environment
+        )
+
+        _sdk_dynamic.SdkDynamicTaskMixin.__init__(self, allowed_failure_ratio, max_concurrency)

--- a/flytekit/common/tasks/sidecar_task.py
+++ b/flytekit/common/tasks/sidecar_task.py
@@ -170,17 +170,6 @@ class SdkDynamicSidecarTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _sdk
                  environment,
                  pod_spec=None,
                  primary_container_name=None):
-        """
-        :param _sdk_runnable.SdkRunnableTask sdk_runnable_task:
-        :param generated_pb2.PodSpec pod_spec:
-        :param Text primary_container_name:
-        :raises: flytekit.common.exceptions.user.FlyteValidationException
-        """
-        if not pod_spec:
-            raise _user_exceptions.FlyteValidationException("A pod spec cannot be undefined")
-        if not primary_container_name:
-            raise _user_exceptions.FlyteValidationException("A primary container name cannot be undefined")
-
         SdkSidecarTask.__init__(
             self,
             task_function,
@@ -199,7 +188,9 @@ class SdkDynamicSidecarTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _sdk
             memory_limit,
             discoverable,
             timeout,
-            environment
+            environment,
+            pod_spec=pod_spec,
+            primary_container_name=primary_container_name
         )
 
         _sdk_dynamic.SdkDynamicTaskMixin.__init__(self, allowed_failure_ratio, max_concurrency)

--- a/flytekit/common/tasks/sidecar_task.py
+++ b/flytekit/common/tasks/sidecar_task.py
@@ -142,12 +142,6 @@ class SdkSidecarTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _sdk_runnab
 
 
 class SdkDynamicSidecarTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _sdk_dynamic.SdkDynamicTaskMixin, SdkSidecarTask)):
-
-    """
-    This class includes the additional logic for building a task that executes as a Sidecar Job.
-
-    """
-
     def __init__(self,
                  task_function,
                  task_type,

--- a/flytekit/common/tasks/sidecar_task.py
+++ b/flytekit/common/tasks/sidecar_task.py
@@ -15,7 +15,7 @@ from google.protobuf.json_format import MessageToDict as _MessageToDict
 from flytekit.plugins import k8s as _lazy_k8s
 
 
-class SdkSidecarTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _sdk_runnable.SdkRunnableTask)):
+class SdkSidecarTask(_sdk_runnable.SdkRunnableTask, metaclass=_sdk_bases.ExtendedSdkType):
 
     """
     This class includes the additional logic for building a task that executes as a Sidecar Job.
@@ -141,7 +141,7 @@ class SdkSidecarTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _sdk_runnab
         self.assign_custom_and_return(_MessageToDict(sidecar_job_plugin))
 
 
-class SdkDynamicSidecarTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _sdk_dynamic.SdkDynamicTaskMixin, SdkSidecarTask)):
+class SdkDynamicSidecarTask(_sdk_dynamic.SdkDynamicTaskMixin, SdkSidecarTask, metaclass=_sdk_bases.ExtendedSdkType):
     def __init__(self,
                  task_function,
                  task_type,

--- a/flytekit/common/tasks/sidecar_task.py
+++ b/flytekit/common/tasks/sidecar_task.py
@@ -142,6 +142,13 @@ class SdkSidecarTask(_sdk_runnable.SdkRunnableTask, metaclass=_sdk_bases.Extende
 
 
 class SdkDynamicSidecarTask(_sdk_dynamic.SdkDynamicTaskMixin, SdkSidecarTask, metaclass=_sdk_bases.ExtendedSdkType):
+
+    """
+    This class includes the additional logic for building a task that runs as
+    a Sidecar Job and executes parent-child tasks.
+
+    """
+
     def __init__(self,
                  task_function,
                  task_type,
@@ -164,6 +171,31 @@ class SdkDynamicSidecarTask(_sdk_dynamic.SdkDynamicTaskMixin, SdkSidecarTask, me
                  environment,
                  pod_spec=None,
                  primary_container_name=None):
+        """
+        :param task_function: Function container user code.  This will be executed via the SDK's engine.
+        :param Text task_type: string describing the task type
+        :param Text discovery_version: string describing the version for task discovery purposes
+        :param int retries: Number of retries to attempt
+        :param bool interruptible: Whether or not task is interruptible
+        :param Text deprecated:
+        :param Text storage_request:
+        :param Text cpu_request:
+        :param Text gpu_request:
+        :param Text memory_request:
+        :param Text storage_limit:
+        :param Text cpu_limit:
+        :param Text gpu_limit:
+        :param Text memory_limit:
+        :param bool discoverable:
+        :param datetime.timedelta timeout:
+        :param float allowed_failure_ratio:
+        :param int max_concurrency:
+        :param dict[Text, Text] environment:
+        :param generated_pb2.PodSpec pod_spec:
+        :param Text primary_container_name:
+        :raises: flytekit.common.exceptions.user.FlyteValidationException
+        """
+
         SdkSidecarTask.__init__(
             self,
             task_function,

--- a/flytekit/common/tasks/sidecar_task.py
+++ b/flytekit/common/tasks/sidecar_task.py
@@ -141,7 +141,7 @@ class SdkSidecarTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _sdk_runnab
         self.assign_custom_and_return(_MessageToDict(sidecar_job_plugin))
 
 
-class SdkDynamicSidecarTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _sdk_dynamic.SdkDynamicTaskMixin, _sdk_runnable.SdkRunnableTask)):
+class SdkDynamicSidecarTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _sdk_dynamic.SdkDynamicTaskMixin, SdkSidecarTask)):
 
     """
     This class includes the additional logic for building a task that executes as a Sidecar Job.

--- a/flytekit/sdk/tasks.py
+++ b/flytekit/sdk/tasks.py
@@ -1028,6 +1028,145 @@ def dynamic_sidecar_task(
         primary_container_name=None,
         cls=None,
 ):
+    """
+    Decorator to create a custom dynamic sidecar task definition. Dynamic
+    tasks should be used to split up work into an arbitrary number of parallel
+    sub-tasks, or workflows. This task will execute the primary task alongside
+    the specified kubernetes PodSpec. Custom primary task container attributes
+    can be defined in the PodSpec by defining a container whose name matches
+    the primary_container_name. These container attributes will be applied to
+    the container brought up to execute the primary task definition.
+
+    .. code-block:: python
+
+        def generate_pod_spec_for_task():
+            pod_spec = generated_pb2.PodSpec()
+            secondary_container = generated_pb2.Container(
+                name="secondary",
+                image="alpine",
+            )
+            secondary_container.command.extend(["/bin/sh"])
+            secondary_container.args.extend(["-c", "echo hi sidecar world > /data/message.txt"])
+            shared_volume_mount = generated_pb2.VolumeMount(
+                name="shared-data",
+                mountPath="/data",
+            )
+            secondary_container.volumeMounts.extend([shared_volume_mount])
+
+            primary_container = generated_pb2.Container(name="primary")
+            primary_container.volumeMounts.extend([shared_volume_mount])
+
+            pod_spec.volumes.extend([generated_pb2.Volume(
+                name="shared-data",
+                volumeSource=generated_pb2.VolumeSource(
+                    emptyDir=generated_pb2.EmptyDirVolumeSource(
+                        medium="Memory",
+                    )
+                )
+            )])
+            pod_spec.containers.extend([primary_container, secondary_container])
+            return pod_spec
+
+        @outputs(out=Types.Integer)
+        @python_task
+        def my_sub_task(wf_params, out):
+            out.set(randint())
+
+        @outputs(out=[Types.Integer])
+        @dynamic_sidecar_task(
+            pod_spec=generate_pod_spec_for_task(),
+            primary_container_name="primary",
+        )
+        def my_task(wf_params, out):
+            out_list = []
+            for i in xrange(100):
+                out_list.append(my_sub_task().outputs.out)
+            out.set(out_list)
+
+    .. note::
+
+        All outputs of a batch task must be a list.  This is because the individual outputs of sub-tasks should be
+        appended into a list.  There cannot be aggregation of outputs done in this task.  To accomplish aggregation,
+        it is recommended that a python_task take the outputs of this task as input and do the necessary work.
+        If a sub-task does not contribute an output, it must be yielded from the task with the `yield` keyword or
+        returned from the task in a list.  If this isn't done, the sub-task will not be executed.
+
+    :param _task_function: this is the decorated method and shouldn't be declared explicitly.  The function must
+        take a first argument, and then named arguments matching those defined in @inputs and @outputs.  No keyword
+        arguments are allowed.
+    :param Text cache_version: [optional] string representing logical version for discovery.  This field should be
+        updated whenever the underlying algorithm changes.
+
+        .. note::
+
+            This argument is required to be a non-empty string if `cache` is True.
+
+    :param int retries: [optional] integer determining number of times task can be retried on
+        :py:exc:`flytekit.sdk.exceptions.RecoverableException` or transient platform failures.  Defaults
+        to 0.
+
+        .. note::
+
+            If retries > 0, the task must be able to recover from any remote state created within the user code.  It is
+            strongly recommended that tasks are written to be idempotent.
+
+    :param bool interruptible: [optional] boolean describing if the task is interruptible.
+
+    :param Text deprecated: [optional] string that should be provided if this task is deprecated.  The string
+        will be logged as a warning so it should contain information regarding how to update to a newer task.
+    :param Text storage_request: [optional] Kubernetes resource string for lower-bound of disk storage space
+        for the task to run.  Default is set by platform-level configuration.
+
+        .. note::
+
+            This is currently not supported by the platform.
+
+    :param Text cpu_request: [optional] Kubernetes resource string for lower-bound of cores for the task to execute.
+        This can be set to a fractional portion of a CPU. Default is set by platform-level configuration.
+        TODO: Add links to resource string documentation for Kubernetes
+    :param Text gpu_request: [optional] Kubernetes resource string for lower-bound of desired GPUs.
+        Default is set by platform-level configuration.
+        TODO: Add links to resource string documentation for Kubernetes
+    :param Text memory_request: [optional]  Kubernetes resource string for lower-bound of physical memory
+        necessary for the task to execute.  Default is set by platform-level configuration.
+        TODO: Add links to resource string documentation for Kubernetes
+    :param Text storage_limit: [optional] Kubernetes resource string for upper-bound of disk storage space
+        for the task to run.  This amount is not guaranteed!  If not specified, it is set equal to storage_request.
+
+        .. note::
+
+            This is currently not supported by the platform.
+
+    :param Text cpu_limit: [optional] Kubernetes resource string for upper-bound of cores for the task to execute.
+        This can be set to a fractional portion of a CPU. This amount is not guaranteed!  If not specified,
+        it is set equal to cpu_request.
+    :param Text gpu_limit: [optional] Kubernetes resource string for upper-bound of desired GPUs. This amount is not
+        guaranteed!  If not specified, it is set equal to gpu_request.
+    :param Text memory_limit: [optional]  Kubernetes resource string for upper-bound of physical memory
+        necessary for the task to execute.  This amount is not guaranteed!  If not specified, it is set equal to
+        memory_request.
+    :param bool cache: [optional] boolean describing if the outputs of this task should be cached and
+        re-usable.
+    :param datetime.timedelta timeout: [optional] describes how long the task should be allowed to
+        run at max before triggering a retry (if retries are enabled).  By default, tasks are allowed to run
+        indefinitely.  If a null timedelta is passed (i.e. timedelta(seconds=0)), the task will not timeout.
+    :param float allowed_failure_ratio: [optional] float value describing the ratio of sub-tasks that may fail before
+        the master batch task considers itself a failure.  By default, the value is 0 so if any task fails, the master
+        batch task will be marked a failure.  If specified, the value must be between 0 and 1 inclusive.  In the event a
+        non-zero value is specified, downstream tasks must be able to accept None values as outputs from individual
+        sub-tasks because the output values will be set to None for any sub-task that fails.
+    :param int max_concurrency: [optional] integer value describing the maximum number of tasks to run concurrently.
+        This is a stand-in pending better concurrency controls for special use-cases.  The existence of this parameter
+        is not guaranteed between versions and therefore it is NOT recommended that it be used.
+    :param dict[Text,Text] environment: [optional] environment variables to set when executing this task.
+    :param k8s.io.api.core.v1.generated_pb2.PodSpec pod_spec: PodSpec to bring up alongside task execution.
+    :param Text primary_container_name: primary container to monitor for the duration of the task.
+    :param cls: This can be used to override the task implementation with a user-defined extension. The class
+        provided must be a subclass of flytekit.common.tasks.sdk_runnable.SdkRunnableTask.  Generally, it should be a
+        subclass of flytekit.common.tasks.sidecar_Task.SdkDynamicSidecarTask.  A user can use this parameter to inject bespoke
+        logic into the base Flyte programming model.
+    :rtype: flytekit.common.tasks.sidecar_Task.SdkDynamicSidecarTask
+    """
     def wrapper(fn):
         return (cls or _sdk_sidecar_tasks.SdkDynamicSidecarTask)(
             task_function=fn,

--- a/flytekit/sdk/tasks.py
+++ b/flytekit/sdk/tasks.py
@@ -1005,6 +1005,60 @@ def sidecar_task(
         return wrapper
 
 
+def dynamic_sidecar_task(
+        _task_function=None,
+        cache_version="",
+        retries=0,
+        interruptible=None,
+        deprecated="",
+        storage_request=None,
+        cpu_request=None,
+        gpu_request=None,
+        memory_request=None,
+        storage_limit=None,
+        cpu_limit=None,
+        gpu_limit=None,
+        memory_limit=None,
+        cache=False,
+        timeout=None,
+        allowed_failure_ratio=None,
+        max_concurrency=None,
+        environment=None,
+        pod_spec=None,
+        primary_container_name=None,
+        cls=None,
+):
+    def wrapper(fn):
+        return (cls or _sdk_sidecar_tasks.SdkDynamicSidecarTask)(
+            task_function=fn,
+            task_type=_common_constants.SdkTaskType.SIDECAR_TASK,
+            discovery_version=cache_version,
+            retries=retries,
+            interruptible=interruptible,
+            deprecated=deprecated,
+            storage_request=storage_request,
+            cpu_request=cpu_request,
+            gpu_request=gpu_request,
+            memory_request=memory_request,
+            storage_limit=storage_limit,
+            cpu_limit=cpu_limit,
+            gpu_limit=gpu_limit,
+            memory_limit=memory_limit,
+            discoverable=cache,
+            timeout=timeout or _datetime.timedelta(seconds=0),
+            allowed_failure_ratio=allowed_failure_ratio,
+            max_concurrency=max_concurrency,
+            environment=environment,
+            pod_spec=pod_spec,
+            primary_container_name=primary_container_name,
+        )
+
+    if _task_function:
+        return wrapper(_task_function)
+    else:
+        return wrapper
+
+
 def pytorch_task(
         _task_function=None,
         cache_version='',

--- a/tests/flytekit/unit/sdk/tasks/test_dynamic_sidecar_tasks.py
+++ b/tests/flytekit/unit/sdk/tasks/test_dynamic_sidecar_tasks.py
@@ -1,0 +1,68 @@
+from __future__ import absolute_import
+
+import mock
+from flytekit.configuration.internal import IMAGE as _IMAGE
+
+from flytekit.common.tasks import sdk_dynamic as _sdk_dynamic, sdk_runnable as _sdk_runnable, sidecar_task as _sidecar_task
+
+from flytekit.sdk.tasks import inputs, outputs, dynamic_sidecar_task, python_task
+from flytekit.sdk.types import Types
+
+from k8s.io.api.core.v1 import generated_pb2
+
+
+def get_pod_spec():
+    a_container = generated_pb2.Container(name="main")
+    a_container.command.extend(["foo", "bar"])
+    a_container.volumeMounts.extend([generated_pb2.VolumeMount(
+        name="scratch",
+        mountPath="/scratch",
+    )])
+
+    pod_spec = generated_pb2.PodSpec(
+        restartPolicy="Never",
+    )
+    pod_spec.containers.extend([a_container, generated_pb2.Container(name="sidecar")])
+    return pod_spec
+
+
+with mock.patch.object(_IMAGE, 'get', return_value='docker.io/blah:abc123'):
+    @outputs(out1=Types.String)
+    @python_task
+    def simple_python_task(wf_params, out1):
+        out1.set("test")
+
+    @inputs(in1=Types.Integer)
+    @outputs(out1=Types.String)
+    @dynamic_sidecar_task(
+        cpu_request='10',
+        memory_limit='2Gi',
+        environment={"foo": "bar"},
+        pod_spec=get_pod_spec(),
+        primary_container_name="main",
+    )
+    def simple_dynamic_sidecar_task(wf_params, in1, out1):
+        yield simple_python_task()
+
+
+def test_dynamic_sidecar_task():
+    assert isinstance(simple_dynamic_sidecar_task, _sdk_runnable.SdkRunnableTask)
+    assert isinstance(simple_dynamic_sidecar_task, _sidecar_task.SdkDynamicSidecarTask)
+    assert isinstance(simple_dynamic_sidecar_task, _sidecar_task.SdkSidecarTask)
+    assert isinstance(simple_dynamic_sidecar_task, _sdk_dynamic.SdkDynamicTaskMixin)
+
+    pod_spec = simple_dynamic_sidecar_task.custom['podSpec']
+    assert pod_spec['restartPolicy'] == 'Never'
+    assert len(pod_spec['containers']) == 2
+    primary_container = pod_spec['containers'][0]
+    assert primary_container['name'] == 'main'
+    assert primary_container['args'] == ['pyflyte-execute', '--task-module',
+                                         'tests.flytekit.unit.sdk.tasks.test_dynamic_sidecar_tasks', '--task-name',
+                                         'simple_dynamic_sidecar_task', '--inputs', '{{.input}}', '--output-prefix',
+                                         '{{.outputPrefix}}']
+    assert primary_container['volumeMounts'] == [{'mountPath': '/scratch', 'name': 'scratch'}]
+    assert {'name': 'foo', 'value': 'bar'} in primary_container['env']
+    assert primary_container['resources'] == {'requests': {'cpu': {'string': '10'}},
+                                              'limits': {'memory': {'string': '2Gi'}}}
+    assert pod_spec['containers'][1]['name'] == 'sidecar'
+    assert simple_dynamic_sidecar_task.custom['primaryContainerName'] == 'main'

--- a/tests/flytekit/unit/sdk/tasks/test_dynamic_tasks.py
+++ b/tests/flytekit/unit/sdk/tasks/test_dynamic_tasks.py
@@ -146,6 +146,7 @@ def dynamic_wf_task(wf_params, task_input_num, out):
 def test_batch_task():
     assert isinstance(sample_batch_task, _sdk_runnable.SdkRunnableTask)
     assert isinstance(sample_batch_task, _sdk_dynamic.SdkDynamicTask)
+    assert isinstance(sample_batch_task, _sdk_dynamic.SdkDynamicTaskMixin)
 
     expected = {
         'out_str': ["I'm the first result", 'hello 0', "I'm after each sub-task result", 'hello 1',


### PR DESCRIPTION
# Adds a new task type: `dynamic_sidecar_task`, that allows for running dynamic tasks with custom pod specs.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The new class `SdkDynamicSidecarTask` is a hybrid of the dynamic and sidecar tasks. The core logic in `SdkDynamicTask` was moved into a mixin (`SdkDynamicTaskMixin`) that was then used as a base in `SdkDynamicTask` and `SdkDynamicSidecarTask` respectively. `SdkDynamicSidecarTask` allows us to use the same mechanisms for specifying custom pod specs in `sidecar_task`s for `dynamic_task`s as well!

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
NA
