### PR TITLE
Bump urllib3 requirement

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 import flytekit.plugins
 
-__version__ = '0.11.6'
+__version__ = '0.11.7'

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "six>=1.9.0,<2.0.0",
         "sortedcontainers>=1.5.9<3.0.0",
         "statsd>=3.0.0,<4.0.0",
-        "urllib3>=1.22,<1.25",
+        "urllib3>=1.22,<2.0.0",
         "wrapt>=1.0.0,<2.0.0",
         "papermill>=1.2.0",
     ],


### PR DESCRIPTION
# TL;DR
We are seeing runtime errors like:
```
[v0wh9mudkz-sub-wf-task-0] terminated with exit code (1). Reason [Error]. Message: 
Traceback (most recent call last):
  File "/opt/venv/lib/python3.6/site-packages/pkg_resources/__init__.py", line 574, in _build_master
    ws.require(__requires__)
  File "/opt/venv/lib/python3.6/site-packages/pkg_resources/__init__.py", line 892, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/opt/venv/lib/python3.6/site-packages/pkg_resources/__init__.py", line 783, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (urllib3 1.24.3 (/opt/venv/lib/python3.6/site-packages), Requirement.parse('urllib3>=1.25.10'), {'responses'})
```

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
We are raising the requirement to 2.x as proper semantic versioning should mean that everything up to that point is backwards compatible.

## Tracking Issue
NA

## Follow-up issue
NA
