### PR TITLE
Use full execution inputs and outputs data

### DIFF
--- a/flytekit/engines/flyte/engine.py
+++ b/flytekit/engines/flyte/engine.py
@@ -433,11 +433,16 @@ class FlyteWorkflowExecution(_common_engine.BaseWorkflowExecution):
         :rtype: flytekit.models.literals.LiteralMap
         """
         client = _FlyteClientManager(_platform_config.URL.get(), insecure=_platform_config.INSECURE.get()).client
-        url_blob = client.get_execution_data(self.sdk_workflow_execution.id)
-        if url_blob.inputs.bytes > 0:
+        execution_data = client.get_execution_data(self.sdk_workflow_execution.id)
+
+        # Inputs are returned inline unless they are too big, in which case a url blob pointing to them is returned.
+        if bool(execution_data.full_inputs.literals):
+            return execution_data.full_inputs
+
+        if execution_data.inputs.bytes > 0:
             with _common_utils.AutoDeletingTempDir() as t:
                 tmp_name = _os.path.join(t.name, "inputs.pb")
-                _data_proxy.Data.get_data(url_blob.inputs.url, tmp_name)
+                _data_proxy.Data.get_data(execution_data.inputs.url, tmp_name)
                 return _literals.LiteralMap.from_flyte_idl(
                     _common_utils.load_proto_from_file(_literals_pb2.LiteralMap, tmp_name)
                 )
@@ -448,11 +453,16 @@ class FlyteWorkflowExecution(_common_engine.BaseWorkflowExecution):
         :rtype: flytekit.models.literals.LiteralMap
         """
         client = _FlyteClientManager(_platform_config.URL.get(), insecure=_platform_config.INSECURE.get()).client
-        url_blob = client.get_execution_data(self.sdk_workflow_execution.id)
-        if url_blob.outputs.bytes > 0:
+        execution_data = client.get_execution_data(self.sdk_workflow_execution.id)
+
+        # Outputs are returned inline unless they are too big, in which case a url blob pointing to them is returned.
+        if bool(execution_data.full_outputs.literals):
+            return execution_data.full_outputs
+
+        if execution_data.outputs.bytes > 0:
             with _common_utils.AutoDeletingTempDir() as t:
                 tmp_name = _os.path.join(t.name, "outputs.pb")
-                _data_proxy.Data.get_data(url_blob.outputs.url, tmp_name)
+                _data_proxy.Data.get_data(execution_data.outputs.url, tmp_name)
                 return _literals.LiteralMap.from_flyte_idl(
                     _common_utils.load_proto_from_file(_literals_pb2.LiteralMap, tmp_name)
                 )
@@ -486,11 +496,16 @@ class FlyteNodeExecution(_common_engine.BaseNodeExecution):
         :rtype: flytekit.models.literals.LiteralMap
         """
         client = _FlyteClientManager(_platform_config.URL.get(), insecure=_platform_config.INSECURE.get()).client
-        url_blob = client.get_node_execution_data(self.sdk_node_execution.id)
-        if url_blob.inputs.bytes > 0:
+        execution_data = client.get_node_execution_data(self.sdk_node_execution.id)
+
+        # Inputs are returned inline unless they are too big, in which case a url blob pointing to them is returned.
+        if bool(execution_data.full_inputs.literals):
+            return execution_data.full_inputs
+
+        if execution_data.inputs.bytes > 0:
             with _common_utils.AutoDeletingTempDir() as t:
                 tmp_name = _os.path.join(t.name, "inputs.pb")
-                _data_proxy.Data.get_data(url_blob.inputs.url, tmp_name)
+                _data_proxy.Data.get_data(execution_data.inputs.url, tmp_name)
                 return _literals.LiteralMap.from_flyte_idl(
                     _common_utils.load_proto_from_file(_literals_pb2.LiteralMap, tmp_name)
                 )
@@ -501,11 +516,16 @@ class FlyteNodeExecution(_common_engine.BaseNodeExecution):
         :rtype: flytekit.models.literals.LiteralMap
         """
         client = _FlyteClientManager(_platform_config.URL.get(), insecure=_platform_config.INSECURE.get()).client
-        url_blob = client.get_node_execution_data(self.sdk_node_execution.id)
-        if url_blob.outputs.bytes > 0:
+        execution_data = client.get_node_execution_data(self.sdk_node_execution.id)
+
+        # Outputs are returned inline unless they are too big, in which case a url blob pointing to them is returned.
+        if bool(execution_data.full_outputs.literals):
+            return execution_data.full_outputs
+
+        if execution_data.outputs.bytes > 0:
             with _common_utils.AutoDeletingTempDir() as t:
                 tmp_name = _os.path.join(t.name, "outputs.pb")
-                _data_proxy.Data.get_data(url_blob.outputs.url, tmp_name)
+                _data_proxy.Data.get_data(execution_data.outputs.url, tmp_name)
                 return _literals.LiteralMap.from_flyte_idl(
                     _common_utils.load_proto_from_file(_literals_pb2.LiteralMap, tmp_name)
                 )
@@ -525,11 +545,16 @@ class FlyteTaskExecution(_common_engine.BaseTaskExecution):
         :rtype: flytekit.models.literals.LiteralMap
         """
         client = _FlyteClientManager(_platform_config.URL.get(), insecure=_platform_config.INSECURE.get()).client
-        url_blob = client.get_task_execution_data(self.sdk_task_execution.id)
-        if url_blob.inputs.bytes > 0:
+        execution_data = client.get_task_execution_data(self.sdk_task_execution.id)
+
+        # Inputs are returned inline unless they are too big, in which case a url blob pointing to them is returned.
+        if bool(execution_data.full_inputs.literals):
+            return execution_data.full_inputs
+
+        if execution_data.inputs.bytes > 0:
             with _common_utils.AutoDeletingTempDir() as t:
                 tmp_name = _os.path.join(t.name, "inputs.pb")
-                _data_proxy.Data.get_data(url_blob.inputs.url, tmp_name)
+                _data_proxy.Data.get_data(execution_data.inputs.url, tmp_name)
                 return _literals.LiteralMap.from_flyte_idl(
                     _common_utils.load_proto_from_file(_literals_pb2.LiteralMap, tmp_name)
                 )
@@ -540,11 +565,16 @@ class FlyteTaskExecution(_common_engine.BaseTaskExecution):
         :rtype: flytekit.models.literals.LiteralMap
         """
         client = _FlyteClientManager(_platform_config.URL.get(), insecure=_platform_config.INSECURE.get()).client
-        url_blob = client.get_task_execution_data(self.sdk_task_execution.id)
-        if url_blob.outputs.bytes > 0:
+        execution_data = client.get_task_execution_data(self.sdk_task_execution.id)
+
+        # Inputs are returned inline unless they are too big, in which case a url blob pointing to them is returned.
+        if bool(execution_data.full_outputs.literals):
+            return execution_data.full_outputs
+
+        if execution_data.outputs.bytes > 0:
             with _common_utils.AutoDeletingTempDir() as t:
                 tmp_name = _os.path.join(t.name, "outputs.pb")
-                _data_proxy.Data.get_data(url_blob.outputs.url, tmp_name)
+                _data_proxy.Data.get_data(execution_data.outputs.url, tmp_name)
                 return _literals.LiteralMap.from_flyte_idl(
                     _common_utils.load_proto_from_file(_literals_pb2.LiteralMap, tmp_name)
                 )

--- a/flytekit/models/execution.py
+++ b/flytekit/models/execution.py
@@ -6,6 +6,7 @@ import flyteidl.admin.task_execution_pb2 as _task_execution_pb2
 import pytz as _pytz
 
 from flytekit.models import common as _common_models
+from flytekit.models import literals as _literals_models
 from flytekit.models.core import execution as _core_execution
 from flytekit.models.core import identifier as _identifier
 
@@ -382,13 +383,17 @@ class _CommonDataResponse(_common_models.FlyteIdlEntity):
     superclass to reduce code duplication until things diverge in the future.
     """
 
-    def __init__(self, inputs, outputs):
+    def __init__(self, inputs, outputs, full_inputs, full_outputs):
         """
         :param _common_models.UrlBlob inputs:
         :param _common_models.UrlBlob outputs:
+        :param _literals_pb2.LiteralMap full_inputs:
+        :param _literals_pb2.LiteralMap full_outputs:
         """
         self._inputs = inputs
         self._outputs = outputs
+        self._full_inputs = full_inputs
+        self._full_outputs = full_outputs
 
     @property
     def inputs(self):
@@ -404,6 +409,20 @@ class _CommonDataResponse(_common_models.FlyteIdlEntity):
         """
         return self._outputs
 
+    @property
+    def full_inputs(self):
+        """
+        :rtype: _literals_pb2.LiteralMap
+        """
+        return self._full_inputs
+
+    @property
+    def full_outputs(self):
+        """
+        :rtype: _literals_pb2.LiteralMap
+        """
+        return self._full_outputs
+
 
 class WorkflowExecutionGetDataResponse(_CommonDataResponse):
     @classmethod
@@ -415,6 +434,8 @@ class WorkflowExecutionGetDataResponse(_CommonDataResponse):
         return cls(
             inputs=_common_models.UrlBlob.from_flyte_idl(pb2_object.inputs),
             outputs=_common_models.UrlBlob.from_flyte_idl(pb2_object.outputs),
+            full_inputs=_literals_models.LiteralMap.from_flyte_idl(pb2_object.full_inputs),
+            full_outputs=_literals_models.LiteralMap.from_flyte_idl(pb2_object.full_outputs),
         )
 
     def to_flyte_idl(self):
@@ -423,6 +444,7 @@ class WorkflowExecutionGetDataResponse(_CommonDataResponse):
         """
         return _execution_pb2.WorkflowExecutionGetDataResponse(
             inputs=self.inputs.to_flyte_idl(), outputs=self.outputs.to_flyte_idl(),
+            full_inputs=self.full_inputs.to_flyte_idl(), full_outputs=self.full_outputs.to_flyte_idl(),
         )
 
 
@@ -436,6 +458,8 @@ class TaskExecutionGetDataResponse(_CommonDataResponse):
         return cls(
             inputs=_common_models.UrlBlob.from_flyte_idl(pb2_object.inputs),
             outputs=_common_models.UrlBlob.from_flyte_idl(pb2_object.outputs),
+            full_inputs=_literals_models.LiteralMap.from_flyte_idl(pb2_object.full_inputs),
+            full_outputs=_literals_models.LiteralMap.from_flyte_idl(pb2_object.full_outputs),
         )
 
     def to_flyte_idl(self):
@@ -444,6 +468,7 @@ class TaskExecutionGetDataResponse(_CommonDataResponse):
         """
         return _task_execution_pb2.TaskExecutionGetDataResponse(
             inputs=self.inputs.to_flyte_idl(), outputs=self.outputs.to_flyte_idl(),
+            full_inputs=self.full_inputs.to_flyte_idl(), full_outputs=self.full_outputs.to_flyte_idl(),
         )
 
 
@@ -457,6 +482,8 @@ class NodeExecutionGetDataResponse(_CommonDataResponse):
         return cls(
             inputs=_common_models.UrlBlob.from_flyte_idl(pb2_object.inputs),
             outputs=_common_models.UrlBlob.from_flyte_idl(pb2_object.outputs),
+            full_inputs=_literals_models.LiteralMap.from_flyte_idl(pb2_object.full_inputs),
+            full_outputs=_literals_models.LiteralMap.from_flyte_idl(pb2_object.full_outputs),
         )
 
     def to_flyte_idl(self):
@@ -465,4 +492,5 @@ class NodeExecutionGetDataResponse(_CommonDataResponse):
         """
         return _node_execution_pb2.NodeExecutionGetDataResponse(
             inputs=self.inputs.to_flyte_idl(), outputs=self.outputs.to_flyte_idl(),
+            full_inputs=self.full_inputs.to_flyte_idl(), full_outputs=self.full_outputs.to_flyte_idl(),
         )

--- a/flytekit/models/execution.py
+++ b/flytekit/models/execution.py
@@ -443,8 +443,10 @@ class WorkflowExecutionGetDataResponse(_CommonDataResponse):
         :rtype: _execution_pb2.WorkflowExecutionGetDataResponse
         """
         return _execution_pb2.WorkflowExecutionGetDataResponse(
-            inputs=self.inputs.to_flyte_idl(), outputs=self.outputs.to_flyte_idl(),
-            full_inputs=self.full_inputs.to_flyte_idl(), full_outputs=self.full_outputs.to_flyte_idl(),
+            inputs=self.inputs.to_flyte_idl(),
+            outputs=self.outputs.to_flyte_idl(),
+            full_inputs=self.full_inputs.to_flyte_idl(),
+            full_outputs=self.full_outputs.to_flyte_idl(),
         )
 
 
@@ -467,8 +469,10 @@ class TaskExecutionGetDataResponse(_CommonDataResponse):
         :rtype: _task_execution_pb2.TaskExecutionGetDataResponse
         """
         return _task_execution_pb2.TaskExecutionGetDataResponse(
-            inputs=self.inputs.to_flyte_idl(), outputs=self.outputs.to_flyte_idl(),
-            full_inputs=self.full_inputs.to_flyte_idl(), full_outputs=self.full_outputs.to_flyte_idl(),
+            inputs=self.inputs.to_flyte_idl(),
+            outputs=self.outputs.to_flyte_idl(),
+            full_inputs=self.full_inputs.to_flyte_idl(),
+            full_outputs=self.full_outputs.to_flyte_idl(),
         )
 
 
@@ -491,6 +495,8 @@ class NodeExecutionGetDataResponse(_CommonDataResponse):
         :rtype: _node_execution_pb2.NodeExecutionGetDataResponse
         """
         return _node_execution_pb2.NodeExecutionGetDataResponse(
-            inputs=self.inputs.to_flyte_idl(), outputs=self.outputs.to_flyte_idl(),
-            full_inputs=self.full_inputs.to_flyte_idl(), full_outputs=self.full_outputs.to_flyte_idl(),
+            inputs=self.inputs.to_flyte_idl(),
+            outputs=self.outputs.to_flyte_idl(),
+            full_inputs=self.full_inputs.to_flyte_idl(),
+            full_outputs=self.full_outputs.to_flyte_idl(),
         )

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         ]
     },
     install_requires=[
-        "flyteidl>=0.18.1,<1.0.0",
+        "flyteidl>=0.18.2,<1.0.0",
         "click>=6.6,<8.0",
         "croniter>=0.3.20,<4.0.0",
         "deprecated>=1.0,<2.0",

--- a/tests/flytekit/unit/engines/flyte/test_engine.py
+++ b/tests/flytekit/unit/engines/flyte/test_engine.py
@@ -256,9 +256,7 @@ def test_fetch_active_launch_plan(mock_client_factory):
 def test_get_full_execution_inputs(mock_client_factory):
     mock_client = MagicMock()
     mock_client.get_execution_data = MagicMock(
-        return_value=_execution_models.WorkflowExecutionGetDataResponse(
-            None, None, _INPUT_MAP, _OUTPUT_MAP,
-        )
+        return_value=_execution_models.WorkflowExecutionGetDataResponse(None, None, _INPUT_MAP, _OUTPUT_MAP,)
     )
     mock_client_factory.return_value = mock_client
 
@@ -298,9 +296,7 @@ def test_get_execution_inputs(mock_client_factory, execution_data_locations):
 def test_get_full_execution_outputs(mock_client_factory):
     mock_client = MagicMock()
     mock_client.get_execution_data = MagicMock(
-        return_value=_execution_models.WorkflowExecutionGetDataResponse(
-            None, None, _INPUT_MAP, _OUTPUT_MAP
-        )
+        return_value=_execution_models.WorkflowExecutionGetDataResponse(None, None, _INPUT_MAP, _OUTPUT_MAP)
     )
     mock_client_factory.return_value = mock_client
 
@@ -340,9 +336,7 @@ def test_get_execution_outputs(mock_client_factory, execution_data_locations):
 def test_get_full_node_execution_inputs(mock_client_factory):
     mock_client = MagicMock()
     mock_client.get_node_execution_data = MagicMock(
-        return_value=_execution_models.NodeExecutionGetDataResponse(
-            None, None, _INPUT_MAP, _OUTPUT_MAP,
-        )
+        return_value=_execution_models.NodeExecutionGetDataResponse(None, None, _INPUT_MAP, _OUTPUT_MAP,)
     )
     mock_client_factory.return_value = mock_client
 
@@ -394,9 +388,7 @@ def test_get_node_execution_inputs(mock_client_factory, execution_data_locations
 def test_get_full_node_execution_outputs(mock_client_factory):
     mock_client = MagicMock()
     mock_client.get_node_execution_data = MagicMock(
-        return_value=_execution_models.NodeExecutionGetDataResponse(
-            None, None, _INPUT_MAP, _OUTPUT_MAP
-        )
+        return_value=_execution_models.NodeExecutionGetDataResponse(None, None, _INPUT_MAP, _OUTPUT_MAP)
     )
     mock_client_factory.return_value = mock_client
 
@@ -448,9 +440,7 @@ def test_get_node_execution_outputs(mock_client_factory, execution_data_location
 def test_get_full_task_execution_inputs(mock_client_factory):
     mock_client = MagicMock()
     mock_client.get_task_execution_data = MagicMock(
-        return_value=_execution_models.TaskExecutionGetDataResponse(
-            None, None, _INPUT_MAP, _OUTPUT_MAP
-        )
+        return_value=_execution_models.TaskExecutionGetDataResponse(None, None, _INPUT_MAP, _OUTPUT_MAP)
     )
     mock_client_factory.return_value = mock_client
 
@@ -518,9 +508,7 @@ def test_get_task_execution_inputs(mock_client_factory, execution_data_locations
 def test_get_full_task_execution_outputs(mock_client_factory):
     mock_client = MagicMock()
     mock_client.get_task_execution_data = MagicMock(
-        return_value=_execution_models.TaskExecutionGetDataResponse(
-            None, None, _INPUT_MAP, _OUTPUT_MAP
-        )
+        return_value=_execution_models.TaskExecutionGetDataResponse(None, None, _INPUT_MAP, _OUTPUT_MAP)
     )
     mock_client_factory.return_value = mock_client
 

--- a/tests/flytekit/unit/models/test_execution.py
+++ b/tests/flytekit/unit/models/test_execution.py
@@ -4,9 +4,17 @@ import pytest
 
 from flytekit.models import common as _common_models
 from flytekit.models import execution as _execution
+from flytekit.models import literals as _literals
 from flytekit.models.core import execution as _core_exec
 from flytekit.models.core import identifier as _identifier
 from tests.flytekit.common import parameterizers as _parameterizers
+
+_INPUT_MAP = _literals.LiteralMap(
+    {"a": _literals.Literal(scalar=_literals.Scalar(primitive=_literals.Primitive(integer=1)))}
+)
+_OUTPUT_MAP = _literals.LiteralMap(
+    {"b": _literals.Literal(scalar=_literals.Scalar(primitive=_literals.Primitive(integer=2)))}
+)
 
 
 def test_execution_metadata():
@@ -104,28 +112,34 @@ def test_execution_spec(literal_value_pair):
 def test_workflow_execution_data_response():
     input_blob = _common_models.UrlBlob("in", 1)
     output_blob = _common_models.UrlBlob("out", 2)
-    obj = _execution.WorkflowExecutionGetDataResponse(input_blob, output_blob)
+    obj = _execution.WorkflowExecutionGetDataResponse(input_blob, output_blob, _INPUT_MAP, _OUTPUT_MAP)
     obj2 = _execution.WorkflowExecutionGetDataResponse.from_flyte_idl(obj.to_flyte_idl())
     assert obj == obj2
     assert obj2.inputs == input_blob
     assert obj2.outputs == output_blob
+    assert obj2.full_inputs == _INPUT_MAP
+    assert obj2.full_outputs == _OUTPUT_MAP
 
 
 def test_node_execution_data_response():
     input_blob = _common_models.UrlBlob("in", 1)
     output_blob = _common_models.UrlBlob("out", 2)
-    obj = _execution.NodeExecutionGetDataResponse(input_blob, output_blob)
+    obj = _execution.NodeExecutionGetDataResponse(input_blob, output_blob, _INPUT_MAP, _OUTPUT_MAP)
     obj2 = _execution.NodeExecutionGetDataResponse.from_flyte_idl(obj.to_flyte_idl())
     assert obj == obj2
     assert obj2.inputs == input_blob
     assert obj2.outputs == output_blob
+    assert obj2.full_inputs == _INPUT_MAP
+    assert obj2.full_outputs == _OUTPUT_MAP
 
 
 def test_task_execution_data_response():
     input_blob = _common_models.UrlBlob("in", 1)
     output_blob = _common_models.UrlBlob("out", 2)
-    obj = _execution.TaskExecutionGetDataResponse(input_blob, output_blob)
+    obj = _execution.TaskExecutionGetDataResponse(input_blob, output_blob, _INPUT_MAP, _OUTPUT_MAP)
     obj2 = _execution.TaskExecutionGetDataResponse.from_flyte_idl(obj.to_flyte_idl())
     assert obj == obj2
     assert obj2.inputs == input_blob
     assert obj2.outputs == output_blob
+    assert obj2.full_inputs == _INPUT_MAP
+    assert obj2.full_outputs == _OUTPUT_MAP


### PR DESCRIPTION
# TL;DR
Building off of https://github.com/lyft/flyte/issues/419, this change reads full execution input and output data when it is returned inline.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/478

## Follow-up issue
_NA_
