### PR TITLE
Add support for flytekit[all3] with Spark 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To install all or multiple available plugins, one can specify them individually:
 pip install "flytekit[sidecar,spark,schema]"
 ```
 
-Or install them with the `all` or `all3` directives: `all` defaults to Spark 2.4.x while `all3` defaults to Spark 3.x currently.
+Or install them with the `all` or `all-spark3` directives: `all` defaults to Spark 2.4.x while `all-spark3` defaults to Spark 3.x currently.
 In a future release (starting 0.15.x), support for Spark 2.4 will be deprecated and `all` will be switched to use Spark 3.x.
 
 

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ To install all or multiple available plugins, one can specify them individually:
 pip install "flytekit[sidecar,spark,schema]"
 ```
 
-Or install them with the `all` or `all-spark3` directives: `all` defaults to Spark 2.4.x while `all-spark3` defaults to Spark 3.x currently.
-In a future release (starting 0.15.x), support for Spark 2.4 will be deprecated and `all` will be switched to use Spark 3.x.
+Or install them with the `all` or `all-spark2.4` or `all-spark3` directives which will install all the plugins and a specific Spark version.
+ Please note that `all` currently defaults to Spark 2.4.x. In a future release (starting 0.15.x), `all` will be switched to use Spark 3.x.
 
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ To install all or multiple available plugins, one can specify them individually:
 pip install "flytekit[sidecar,spark,schema]"
 ```
 
-Or install them with the `all` directive. `all` defaults to Spark 2.4.x currently.
+Or install them with the `all` or `all3` directives: `all` defaults to Spark 2.4.x while `all3` defaults to Spark 3.x currently.
+In a future release (starting 0.15.x), support for Spark 2.4 will be deprecated and `all` will be switched to use Spark 3.x.
+
 
 ```bash
 pip install "flytekit[all]"

--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 import flytekit.plugins  # noqa: F401
 
-__version__ = "0.12.0b1"
+__version__ = "0.12.0"

--- a/flytekit/tools/lazy_loader.py
+++ b/flytekit/tools/lazy_loader.py
@@ -26,16 +26,16 @@ class LazyLoadPlugin(object):
         """
         d = cls.LAZY_LOADING_PLUGINS.copy()
         all_plugins = []
-        all_plugins3 = []
+        all_plugins_spark3 = []
         for k in d:
-            # Default to Spark 2.4.x in all and Spark 3.x in all3.
+            # Default to Spark 2.4.x in all and Spark 3.x in all-spark3.
             if k != "spark3":
                 all_plugins.extend(d[k])
             if k != "spark":
-                all_plugins3.extend(d[k])
+                all_plugins_spark3.extend(d[k])
 
         d["all"] = all_plugins
-        d["all-spark3"] = all_plugins3
+        d["all-spark3"] = all_plugins_spark3
         return d
 
 

--- a/flytekit/tools/lazy_loader.py
+++ b/flytekit/tools/lazy_loader.py
@@ -32,7 +32,7 @@ class LazyLoadPlugin(object):
             if k != "spark3":
                 all_plugins.extend(d[k])
             if k != "spark":
-                all_plugins3.extend(d[k])               
+                all_plugins3.extend(d[k])
 
         d["all"] = all_plugins
         d["all3"] = all_plugins3

--- a/flytekit/tools/lazy_loader.py
+++ b/flytekit/tools/lazy_loader.py
@@ -25,17 +25,19 @@ class LazyLoadPlugin(object):
         :rtype: dict[Text,list[Text]]
         """
         d = cls.LAZY_LOADING_PLUGINS.copy()
-        all_plugins = []
+        all_plugins_spark2 = []
         all_plugins_spark3 = []
         for k in d:
-            # Default to Spark 2.4.x in all and Spark 3.x in all-spark3.
+            # Default to Spark 2.4.x in all-spark2 and Spark 3.x in all-spark3.
             if k != "spark3":
-                all_plugins.extend(d[k])
+                all_plugins_spark2.extend(d[k])
             if k != "spark":
                 all_plugins_spark3.extend(d[k])
 
-        d["all"] = all_plugins
+        d["all-spark2.4"] = all_plugins_spark2
         d["all-spark3"] = all_plugins_spark3
+        # all points to Spark 2.4
+        d["all"] = all_plugins_spark2
         return d
 
 

--- a/flytekit/tools/lazy_loader.py
+++ b/flytekit/tools/lazy_loader.py
@@ -35,7 +35,7 @@ class LazyLoadPlugin(object):
                 all_plugins3.extend(d[k])
 
         d["all"] = all_plugins
-        d["all3"] = all_plugins3
+        d["all-spark3"] = all_plugins3
         return d
 
 

--- a/flytekit/tools/lazy_loader.py
+++ b/flytekit/tools/lazy_loader.py
@@ -26,12 +26,16 @@ class LazyLoadPlugin(object):
         """
         d = cls.LAZY_LOADING_PLUGINS.copy()
         all_plugins = []
+        all_plugins3 = []
         for k in d:
-            # Default to Spark 2.4.x .
+            # Default to Spark 2.4.x in all and Spark 3.x in all3.
             if k != "spark3":
                 all_plugins.extend(d[k])
+            if k != "spark":
+                all_plugins3.extend(d[k])               
 
         d["all"] = all_plugins
+        d["all3"] = all_plugins3
         return d
 
 


### PR DESCRIPTION
Add support for `all` with Spark 3.x. 
Ref: https://github.com/lyft/flyte/issues/482  and https://github.com/lyft/flyte/issues/483 to move default to Spark 3.x at some point. 

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/482

## Follow-up issue
https://github.com/lyft/flyte/issues/483
