### PR TITLE
Add --raw-output-data-prefix to the pyflyte-execute command

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 import flytekit.plugins  # noqa: F401
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -83,10 +83,8 @@ def _execute_task(task_module, task_name, inputs, output_prefix, raw_output_data
                 _data_proxy.Data.get_data(inputs, local_inputs_file)
                 input_proto = _utils.load_proto_from_file(_literals_pb2.LiteralMap, local_inputs_file)
                 _engine_loader.get_engine().get_task(task_def).execute(
-                    _literal_models.LiteralMap.from_flyte_idl(input_proto), context={
-                        "output_prefix": output_prefix,
-                        "raw_output_data_prefix": raw_output_data_prefix,
-                    },
+                    _literal_models.LiteralMap.from_flyte_idl(input_proto),
+                    context={"output_prefix": output_prefix, "raw_output_data_prefix": raw_output_data_prefix,},
                 )
 
 
@@ -100,10 +98,16 @@ def _pass_through():
 @_click.option("--task-name", required=True)
 @_click.option("--inputs", required=True)
 @_click.option("--output-prefix", required=True)
-@_click.option("--raw-data-output-prefix", required=False)
+@_click.option("--raw-output-data-prefix", required=False)
 @_click.option("--test", is_flag=True)
 def execute_task_cmd(task_module, task_name, inputs, output_prefix, raw_output_data_prefix, test):
     _click.echo(_utils.get_version_message())
+    # Backwards compatibility - if Propeller hasn't filled this in, then it'll come through here as the original
+    # template string, so let's explicitly set it to None so that the downstream functions will know to fall back
+    # to the original shard formatter/prefix config.
+    if raw_output_data_prefix == "{{.rawOutputDataPrefix}}":
+        raw_output_data_prefix = None
+
     _execute_task(task_module, task_name, inputs, output_prefix, raw_output_data_prefix, test)
 
 

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -84,7 +84,7 @@ def _execute_task(task_module, task_name, inputs, output_prefix, raw_output_data
                 input_proto = _utils.load_proto_from_file(_literals_pb2.LiteralMap, local_inputs_file)
                 _engine_loader.get_engine().get_task(task_def).execute(
                     _literal_models.LiteralMap.from_flyte_idl(input_proto),
-                    context={"output_prefix": output_prefix, "raw_output_data_prefix": raw_output_data_prefix,},
+                    context={"output_prefix": output_prefix, "raw_output_data_prefix": raw_output_data_prefix},
                 )
 
 

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -53,7 +53,7 @@ def _map_job_index_to_child_index(local_input_dir, datadir, index):
 
 
 @_scopes.system_entry_point
-def _execute_task(task_module, task_name, inputs, output_prefix, test):
+def _execute_task(task_module, task_name, inputs, output_prefix, raw_output_data_prefix, test):
     with _TemporaryConfiguration(_internal_config.CONFIGURATION_PATH.get()):
         with _utils.AutoDeletingTempDir("input_dir") as input_dir:
             # Load user code
@@ -83,7 +83,10 @@ def _execute_task(task_module, task_name, inputs, output_prefix, test):
                 _data_proxy.Data.get_data(inputs, local_inputs_file)
                 input_proto = _utils.load_proto_from_file(_literals_pb2.LiteralMap, local_inputs_file)
                 _engine_loader.get_engine().get_task(task_def).execute(
-                    _literal_models.LiteralMap.from_flyte_idl(input_proto), context={"output_prefix": output_prefix},
+                    _literal_models.LiteralMap.from_flyte_idl(input_proto), context={
+                        "output_prefix": output_prefix,
+                        "raw_output_data_prefix": raw_output_data_prefix,
+                    },
                 )
 
 
@@ -97,10 +100,11 @@ def _pass_through():
 @_click.option("--task-name", required=True)
 @_click.option("--inputs", required=True)
 @_click.option("--output-prefix", required=True)
+@_click.option("--raw-data-output-prefix", required=False)
 @_click.option("--test", is_flag=True)
-def execute_task_cmd(task_module, task_name, inputs, output_prefix, test):
+def execute_task_cmd(task_module, task_name, inputs, output_prefix, raw_output_data_prefix, test):
     _click.echo(_utils.get_version_message())
-    _execute_task(task_module, task_name, inputs, output_prefix, test)
+    _execute_task(task_module, task_name, inputs, output_prefix, raw_output_data_prefix, test)
 
 
 if __name__ == "__main__":

--- a/flytekit/common/tasks/sdk_runnable.py
+++ b/flytekit/common/tasks/sdk_runnable.py
@@ -448,7 +448,7 @@ class SdkRunnableTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _base_task
                 "--output-prefix",
                 "{{.outputPrefix}}",
                 "--raw-data-output-prefix",
-                "{{.outputPrefix}}"
+                "{{.rawOutputDataPrefix}}",
             ],
             resources=_task_models.Resources(limits=limits, requests=requests),
             env=environment,

--- a/flytekit/common/tasks/sdk_runnable.py
+++ b/flytekit/common/tasks/sdk_runnable.py
@@ -32,13 +32,12 @@ class ExecutionParameters(object):
     decorated function.
     """
 
-    def __init__(self, execution_date, tmp_dir, stats, execution_id, logging, raw_output_data_prefix=None):
+    def __init__(self, execution_date, tmp_dir, stats, execution_id, logging):
         self._stats = stats
         self._execution_date = execution_date
         self._working_directory = tmp_dir
         self._execution_id = execution_id
         self._logging = logging
-        self._raw_output_data_prefix = raw_output_data_prefix
 
     @property
     def stats(self):
@@ -102,16 +101,6 @@ class ExecutionParameters(object):
         :rtype: Text
         """
         return self._execution_id
-
-    @property
-    def raw_output_data_prefix(self) -> str:
-        """
-        This is the prefix/location that offloaded data structures like Blobs and Schemas will use to store data. You
-        shouldn't need to access this from within a task, but it's here just in case
-
-        :rtype: Text
-        """
-        return self._raw_output_data_prefix
 
 
 class SdkRunnableContainer(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _task_models.Container)):
@@ -349,7 +338,6 @@ class SdkRunnableTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _base_task
                 stats=context.stats,
                 logging=context.logging,
                 tmp_dir=context.working_directory,
-                raw_output_data_prefix=context.raw_output_data_prefix,
             ),
             **inputs
         )

--- a/flytekit/common/tasks/sdk_runnable.py
+++ b/flytekit/common/tasks/sdk_runnable.py
@@ -447,7 +447,7 @@ class SdkRunnableTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _base_task
                 "{{.input}}",
                 "--output-prefix",
                 "{{.outputPrefix}}",
-                "--raw-data-output-prefix",
+                "--raw-output-data-prefix",
                 "{{.rawOutputDataPrefix}}",
             ],
             resources=_task_models.Resources(limits=limits, requests=requests),

--- a/flytekit/common/tasks/sdk_runnable.py
+++ b/flytekit/common/tasks/sdk_runnable.py
@@ -32,12 +32,13 @@ class ExecutionParameters(object):
     decorated function.
     """
 
-    def __init__(self, execution_date, tmp_dir, stats, execution_id, logging):
+    def __init__(self, execution_date, tmp_dir, stats, execution_id, logging, raw_output_data_prefix=None):
         self._stats = stats
         self._execution_date = execution_date
         self._working_directory = tmp_dir
         self._execution_id = execution_id
         self._logging = logging
+        self._raw_output_data_prefix = raw_output_data_prefix
 
     @property
     def stats(self):
@@ -101,6 +102,16 @@ class ExecutionParameters(object):
         :rtype: Text
         """
         return self._execution_id
+
+    @property
+    def raw_output_data_prefix(self) -> str:
+        """
+        This is the prefix/location that offloaded data structures like Blobs and Schemas will use to store data. You
+        shouldn't need to access this from within a task, but it's here just in case
+
+        :rtype: Text
+        """
+        return self._raw_output_data_prefix
 
 
 class SdkRunnableContainer(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _task_models.Container)):
@@ -338,6 +349,7 @@ class SdkRunnableTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _base_task
                 stats=context.stats,
                 logging=context.logging,
                 tmp_dir=context.working_directory,
+                raw_output_data_prefix=context.raw_output_data_prefix,
             ),
             **inputs
         )

--- a/flytekit/common/tasks/sdk_runnable.py
+++ b/flytekit/common/tasks/sdk_runnable.py
@@ -447,6 +447,8 @@ class SdkRunnableTask(_six.with_metaclass(_sdk_bases.ExtendedSdkType, _base_task
                 "{{.input}}",
                 "--output-prefix",
                 "{{.outputPrefix}}",
+                "--raw-data-output-prefix",
+                "{{.outputPrefix}}"
             ],
             resources=_task_models.Resources(limits=limits, requests=requests),
             env=environment,

--- a/flytekit/contrib/notebook/tasks.py
+++ b/flytekit/contrib/notebook/tasks.py
@@ -329,7 +329,7 @@ class SdkNotebookTask(_base_tasks.SdkTask):
             "{{.input}}",
             "--output-prefix",
             "{{.outputPrefix}}",
-            "--raw-data-output-prefix",
+            "--raw-output-data-prefix",
             "{{.rawOutputDataPrefix}}",
         ]
         return self._container

--- a/flytekit/contrib/notebook/tasks.py
+++ b/flytekit/contrib/notebook/tasks.py
@@ -329,6 +329,8 @@ class SdkNotebookTask(_base_tasks.SdkTask):
             "{{.input}}",
             "--output-prefix",
             "{{.outputPrefix}}",
+            "--raw-data-output-prefix",
+            "{{.rawOutputDataPrefix}}",
         ]
         return self._container
 

--- a/flytekit/engines/common.py
+++ b/flytekit/engines/common.py
@@ -396,12 +396,13 @@ class BaseExecutionEngineFactory(_six.with_metaclass(_common_models.FlyteABCMeta
 
 
 class EngineContext(object):
-    def __init__(self, execution_date, tmp_dir, stats, execution_id, logging):
+    def __init__(self, execution_date, tmp_dir, stats, execution_id, logging, raw_output_data_prefix=None):
         self._stats = stats
         self._execution_date = execution_date
         self._working_directory = tmp_dir
         self._execution_id = execution_id
         self._logging = logging
+        self._raw_output_data_prefix = raw_output_data_prefix
 
     @property
     def stats(self):
@@ -437,3 +438,7 @@ class EngineContext(object):
         :rtype: flytekit.models.core.identifier.WorkflowExecutionIdentifier
         """
         return self._execution_id
+
+    @property
+    def raw_output_data_prefix(self) -> str:
+        return self._raw_output_data_prefix

--- a/flytekit/engines/flyte/engine.py
+++ b/flytekit/engines/flyte/engine.py
@@ -270,11 +270,11 @@ class FlyteTask(_common_engine.BaseTaskExecutor):
         :param dict[Text, Text] context:
         :rtype: dict[Text, flytekit.models.common.FlyteIdlEntity]
         """
-
         with _common_utils.AutoDeletingTempDir("engine_dir") as temp_dir:
             with _common_utils.AutoDeletingTempDir("task_dir") as task_dir:
                 with _data_proxy.LocalWorkingDirectoryContext(task_dir):
-                    with _data_proxy.RemoteDataContext():
+                    raw_output_data_prefix = context.get("raw_output_data_prefix", None)
+                    with _data_proxy.RemoteDataContext(raw_output_data_prefix_override=raw_output_data_prefix):
                         output_file_dict = dict()
 
                         # This sets the logging level for user code and is the only place an sdk setting gets
@@ -311,6 +311,7 @@ class FlyteTask(_common_engine.BaseTaskExecutor):
                                     ),
                                     logging=_logging,
                                     tmp_dir=task_dir,
+                                    raw_output_data_prefix=context['raw_output_data_prefix'] if "raw_output_data_prefix" in context else None,
                                 ),
                                 inputs,
                             )

--- a/flytekit/engines/flyte/engine.py
+++ b/flytekit/engines/flyte/engine.py
@@ -311,7 +311,9 @@ class FlyteTask(_common_engine.BaseTaskExecutor):
                                     ),
                                     logging=_logging,
                                     tmp_dir=task_dir,
-                                    raw_output_data_prefix=context['raw_output_data_prefix'] if "raw_output_data_prefix" in context else None,
+                                    raw_output_data_prefix=context["raw_output_data_prefix"]
+                                    if "raw_output_data_prefix" in context
+                                    else None,
                                 ),
                                 inputs,
                             )

--- a/flytekit/interfaces/data/data_proxy.py
+++ b/flytekit/interfaces/data/data_proxy.py
@@ -64,22 +64,23 @@ class LocalDataContext(_OutputDataContext):
 class RemoteDataContext(_OutputDataContext):
 
     _CLOUD_PROVIDER_TO_PROXIES = {
-        _constants.CloudProvider.AWS: _s3proxy.AwsS3Proxy(),
-        _constants.CloudProvider.GCP: _gcs_proxy.GCSProxy(),
+        _constants.CloudProvider.AWS: _s3proxy.AwsS3Proxy,
+        _constants.CloudProvider.GCP: _gcs_proxy.GCSProxy,
     }
 
-    def __init__(self, cloud_provider=None):
+    def __init__(self, cloud_provider=None, raw_output_data_prefix_override=None):
         """
         :param Optional[Text] cloud_provider: From flytekit.common.constants.CloudProvider enum
         """
         cloud_provider = cloud_provider or _platform_config.CLOUD_PROVIDER.get()
-        proxy = type(self)._CLOUD_PROVIDER_TO_PROXIES.get(cloud_provider, None)
-        if proxy is None:
+        proxy_class = type(self)._CLOUD_PROVIDER_TO_PROXIES.get(cloud_provider, None)
+        if proxy_class is None:
             raise _user_exception.FlyteAssertion(
                 "Configured cloud provider is not supported for data I/O.  Received: {}, expected one of: {}".format(
                     cloud_provider, list(type(self)._CLOUD_PROVIDER_TO_PROXIES.keys())
                 )
             )
+        proxy = proxy_class(raw_output_data_prefix_override)
         super(RemoteDataContext, self).__init__(proxy)
 
 

--- a/flytekit/interfaces/data/gcs/gcs_proxy.py
+++ b/flytekit/interfaces/data/gcs/gcs_proxy.py
@@ -132,9 +132,10 @@ class GCSProxy(_common_data.DataProxy):
         )
         return _update_cmd_config_and_execute(cmd)
 
-    def get_random_path(self):
+    def get_random_path(self) -> str:
         """
-        :rtype: Text
+        If this object was created with a raw output data prefix, usually set by Propeller/Plugins at execution time
+        and piped all the way here, it will be used instead of referencing the GCS_PREFIX configuration.
         """
         key = _uuid.UUID(int=_flyte_random.random.getrandbits(128)).hex
         prefix = self.raw_output_data_prefix_override or _gcp_config.GCS_PREFIX.get()

--- a/flytekit/interfaces/data/gcs/gcs_proxy.py
+++ b/flytekit/interfaces/data/gcs/gcs_proxy.py
@@ -28,6 +28,19 @@ def _amend_path(path):
 class GCSProxy(_common_data.DataProxy):
     _GS_UTIL_CLI = "gsutil"
 
+    def __init__(self, raw_output_data_prefix_override: str = None):
+        """
+        :param raw_output_data_prefix_override: Instead of relying on the AWS or GCS configuration (see
+            S3_SHARD_FORMATTER for AWS and GCS_PREFIX for GCP) setting when computing the shard
+            path (_get_shard_path), use this prefix instead as a base. This code assumes that the
+            path passed in is correct. That is, an S3 path won't be passed in when running on GCP.
+        """
+        self._raw_output_data_prefix_override = raw_output_data_prefix_override
+
+    @property
+    def raw_output_data_prefix_override(self) -> str:
+        return self._raw_output_data_prefix_override
+
     @staticmethod
     def _check_binary():
         """
@@ -124,7 +137,8 @@ class GCSProxy(_common_data.DataProxy):
         :rtype: Text
         """
         key = _uuid.UUID(int=_flyte_random.random.getrandbits(128)).hex
-        return _os.path.join(_gcp_config.GCS_PREFIX.get(), key)
+        prefix = self.raw_output_data_prefix_override or _gcp_config.GCS_PREFIX.get()
+        return _os.path.join(prefix, key)
 
     def get_random_directory(self):
         """

--- a/tests/flytekit/unit/bin/test_python_entrypoint.py
+++ b/tests/flytekit/unit/bin/test_python_entrypoint.py
@@ -152,8 +152,8 @@ def test_backwards_compatible_replacement(mock_execute_task):
         os.path.join(os.path.dirname(__file__), "fake.config"),
         internal_overrides={"project": "test", "domain": "development"},
     ):
-        with _utils.AutoDeletingTempDir("in") as input_dir:
-            with _utils.AutoDeletingTempDir("out") as output_dir:
+        with _utils.AutoDeletingTempDir("in"):
+            with _utils.AutoDeletingTempDir("out"):
                 cmd = []
                 cmd.extend(["--task-module", "fake"])
                 cmd.extend(["--task-name", "fake"])

--- a/tests/flytekit/unit/interfaces/data/gcs/test_gcs_proxy.py
+++ b/tests/flytekit/unit/interfaces/data/gcs/test_gcs_proxy.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import os as _os
 
 import mock as _mock
@@ -69,3 +67,14 @@ def test_upload_directory_with_parallelism(mock_update_cmd_config_and_execute, g
     local_path, remote_path = "/foo/*", "gs://bar/0/"
     gcs_proxy.upload_directory(local_path, remote_path)
     mock_update_cmd_config_and_execute.assert_called_once_with(["gsutil", "-m", "cp", "-r", local_path, remote_path])
+
+
+def test_raw_prefix_property(mock_update_cmd_config_and_execute, gsutil_parallelism, gcs_proxy):
+    gcs_with_raw_prefix = _gcs_proxy.GCSProxy("gcs://stuff")
+    assert gcs_with_raw_prefix.raw_output_data_prefix_override == "gcs://stuff"
+
+
+def test_random_path(mock_update_cmd_config_and_execute, gsutil_parallelism, gcs_proxy):
+    gcs_with_raw_prefix = _gcs_proxy.GCSProxy("gcs://stuff")
+    result = gcs_with_raw_prefix.get_random_path()
+    assert result.startswith("gcs://stuff")

--- a/tests/flytekit/unit/interfaces/data/s3/test_s3_proxy.py
+++ b/tests/flytekit/unit/interfaces/data/s3/test_s3_proxy.py
@@ -1,0 +1,27 @@
+import os as _os
+
+import mock as _mock
+import pytest as _pytest
+from flytekit.configuration import aws as _aws_config
+
+from flytekit.interfaces.data.s3.s3proxy import AwsS3Proxy as _AwsS3Proxy
+
+
+def test_property():
+    aws = _AwsS3Proxy("s3://raw-output")
+    assert aws.raw_output_data_prefix_override == "s3://raw-output"
+
+
+@_mock.patch("flytekit.configuration.aws.S3_SHARD_FORMATTER")
+def test_random_path(mock_formatter):
+    mock_formatter.get.return_value = "s3://flyte/{}/"
+
+    # Without raw output data prefix override
+    aws = _AwsS3Proxy()
+    p = str(aws.get_random_path())
+    assert p.startswith("s3://flyte")
+
+    # With override
+    aws = _AwsS3Proxy("s3://raw-output")
+    p = str(aws.get_random_path())
+    assert p.startswith("s3://raw-output")

--- a/tests/flytekit/unit/interfaces/data/s3/test_s3_proxy.py
+++ b/tests/flytekit/unit/interfaces/data/s3/test_s3_proxy.py
@@ -1,8 +1,4 @@
-import os as _os
-
 import mock as _mock
-import pytest as _pytest
-from flytekit.configuration import aws as _aws_config
 
 from flytekit.interfaces.data.s3.s3proxy import AwsS3Proxy as _AwsS3Proxy
 

--- a/tests/flytekit/unit/sdk/tasks/test_dynamic_sidecar_tasks.py
+++ b/tests/flytekit/unit/sdk/tasks/test_dynamic_sidecar_tasks.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import mock
 from k8s.io.api.core.v1 import generated_pb2
 
@@ -62,6 +60,8 @@ def test_dynamic_sidecar_task():
         "{{.input}}",
         "--output-prefix",
         "{{.outputPrefix}}",
+        "--raw-output-data-prefix",
+        "{{.rawOutputDataPrefix}}",
     ]
     assert primary_container["volumeMounts"] == [{"mountPath": "/scratch", "name": "scratch"}]
     assert {"name": "foo", "value": "bar"} in primary_container["env"]

--- a/tests/flytekit/unit/sdk/tasks/test_sidecar_tasks.py
+++ b/tests/flytekit/unit/sdk/tasks/test_sidecar_tasks.py
@@ -58,6 +58,8 @@ def test_sidecar_task():
         "{{.input}}",
         "--output-prefix",
         "{{.outputPrefix}}",
+        "--raw-output-data-prefix",
+        "{{.rawOutputDataPrefix}}",
     ]
     assert primary_container["volumeMounts"] == [{"mountPath": "some/where", "name": "volume mount"}]
     assert {"name": "foo", "value": "bar"} in primary_container["env"]


### PR DESCRIPTION
# TL;DR
Please see the linked issue for more information.  This adds a `--raw-output-data-prefix` switch to the pyflyte-execute command and container args will be changed so that they're registered with `--raw-data-output-prefix {{.rawOutputDataPrefix}}`.  Propeller will then fill them in.

*Release this change last, after testing propeller/plugins*

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
* The AWS and GCP data proxy classes now take in its constructor a prefix which will be used when `get_random_path` is called.  If it is missing it will fall back to the current behavior of looking up either the S3 shard formatter config or the GCS prefix config.
* Added switch to click command
* Added switch and template placeholder to sdk runnable task and notebook task container args.

## Tracking Issue
https://github.com/lyft/flyte/issues/211

## Follow-up issue
NA
