### PR TITLE
Add a flag to disable default launch plan generation

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 import flytekit.plugins  # noqa: F401
 
-__version__ = "0.12.4"
+__version__ = "0.12.5"

--- a/flytekit/common/workflow.py
+++ b/flytekit/common/workflow.py
@@ -93,15 +93,16 @@ class SdkWorkflow(
     )
 ):
     def __init__(
-        self,
-        inputs,
-        outputs,
-        nodes,
-        id=None,
-        metadata=None,
-        metadata_defaults=None,
-        interface=None,
-        output_bindings=None,
+            self,
+            inputs,
+            outputs,
+            nodes,
+            id=None,
+            metadata=None,
+            metadata_defaults=None,
+            interface=None,
+            output_bindings=None,
+            disable_default_launch_plan=False,
     ):
         """
         :param list[flytekit.common.promise.Input] inputs:
@@ -117,6 +118,7 @@ class SdkWorkflow(
             the interface field must be bound
             in order for the workflow to be validated. A workflow has an implicit dependency on all of its nodes
             to execute successfully in order to bind final outputs.
+        :param bool disable_default_launch_plan: Determines whether to create a default launch plan for the workflow.
 
         """
         for n in nodes:
@@ -164,6 +166,15 @@ class SdkWorkflow(
         )
         self._user_inputs = inputs
         self._upstream_entities = set(n.executable_sdk_object for n in nodes)
+        self._should_create_default_launch_plan = not disable_default_launch_plan
+
+    @property
+    def should_create_default_launch_plan(self):
+        """
+        Determines whether registration flow should create a default launch plan for this workflow or not.
+        :rtype: bool
+        """
+        return self._should_create_default_launch_plan
 
     @property
     def upstream_entities(self):
@@ -475,12 +486,14 @@ def _discover_workflow_components(workflow_class):
     return inputs, outputs, nodes
 
 
-def build_sdk_workflow_from_metaclass(metaclass, on_failure=None, cls=None):
+def build_sdk_workflow_from_metaclass(metaclass, on_failure=None, disable_default_launch_plan=False, cls=None):
     """
     :param T metaclass:
     :param cls: This is the class that will be instantiated from the inputs, outputs, and nodes.  This will be used
         by users extending the base Flyte programming model. If set, it must be a subclass of SdkWorkflow.
-    :param on_failure flytekit.models.core.workflow.WorkflowMetadata.OnFailurePolicy: [Optional] The execution policy when the workflow detects a failure.
+    :param flytekit.models.core.workflow.WorkflowMetadata.OnFailurePolicy on_failure: [Optional] The execution policy
+        when the workflow detects a failure.
+    :param bool disable_default_launch_plan: Determines whether to create a default launch plan for the workflow or not.
     :rtype: SdkWorkflow
     """
     inputs, outputs, nodes = _discover_workflow_components(metaclass)
@@ -490,4 +503,5 @@ def build_sdk_workflow_from_metaclass(metaclass, on_failure=None, cls=None):
         outputs=[o for o in sorted(outputs, key=lambda x: x.name)],
         nodes=[n for n in sorted(nodes, key=lambda x: x.id)],
         metadata=metadata,
+        disable_default_launch_plan=disable_default_launch_plan,
     )

--- a/flytekit/common/workflow.py
+++ b/flytekit/common/workflow.py
@@ -93,16 +93,16 @@ class SdkWorkflow(
     )
 ):
     def __init__(
-            self,
-            inputs,
-            outputs,
-            nodes,
-            id=None,
-            metadata=None,
-            metadata_defaults=None,
-            interface=None,
-            output_bindings=None,
-            disable_default_launch_plan=False,
+        self,
+        inputs,
+        outputs,
+        nodes,
+        id=None,
+        metadata=None,
+        metadata_defaults=None,
+        interface=None,
+        output_bindings=None,
+        disable_default_launch_plan=False,
     ):
         """
         :param list[flytekit.common.promise.Input] inputs:

--- a/flytekit/sdk/workflow.py
+++ b/flytekit/sdk/workflow.py
@@ -42,7 +42,7 @@ class Output(_common_workflow.Output):
         )
 
 
-def workflow_class(_workflow_metaclass=None, cls=None, on_failure=None):
+def workflow_class(_workflow_metaclass=None, on_failure=None, disable_default_launch_plan=False, cls=None):
     """
     This is a decorator for wrapping class definitions into workflows.
 
@@ -62,12 +62,16 @@ def workflow_class(_workflow_metaclass=None, cls=None, on_failure=None):
     :param cls: This is the class that will be instantiated from the inputs, outputs, and nodes. This will be used
         by users extending the base Flyte programming model. If set, it must be a subclass of
         :py:class:`flytekit.common.workflow.SdkWorkflow`.
-    :param on_failure flytekit.models.core.workflow.WorkflowMetadata.OnFailurePolicy: [Optional] The execution policy when the workflow detects a failure.
+    :param flytekit.models.core.workflow.WorkflowMetadata.OnFailurePolicy on_failure: [Optional] The execution policy
+        when the workflow detects a failure.
+    :param bool disable_default_launch_plan: Determines whether to create a default launch plan for the workflow or not.
+
     :rtype: flytekit.common.workflow.SdkWorkflow
     """
 
     def wrapper(metaclass):
-        wf = _common_workflow.build_sdk_workflow_from_metaclass(metaclass, cls=cls, on_failure=on_failure)
+        wf = _common_workflow.build_sdk_workflow_from_metaclass(
+            metaclass, on_failure=on_failure, disable_default_launch_plan=disable_default_launch_plan, cls=cls)
         return wf
 
     if _workflow_metaclass is not None:

--- a/flytekit/sdk/workflow.py
+++ b/flytekit/sdk/workflow.py
@@ -71,7 +71,8 @@ def workflow_class(_workflow_metaclass=None, on_failure=None, disable_default_la
 
     def wrapper(metaclass):
         wf = _common_workflow.build_sdk_workflow_from_metaclass(
-            metaclass, on_failure=on_failure, disable_default_launch_plan=disable_default_launch_plan, cls=cls)
+            metaclass, on_failure=on_failure, disable_default_launch_plan=disable_default_launch_plan, cls=cls
+        )
         return wf
 
     if _workflow_metaclass is not None:

--- a/flytekit/tools/module_loader.py
+++ b/flytekit/tools/module_loader.py
@@ -110,7 +110,7 @@ def iterate_registerable_entities_in_order(
             if isinstance(o, _registerable.RegisterableEntity):
                 if o.instantiated_in == m.__name__:
                     entity_to_module_key[o] = (m, k)
-                    if isinstance(o, _SdkWorkflow) and o.should_create_launch_plan:
+                    if isinstance(o, _SdkWorkflow) and o.should_create_default_launch_plan:
                         # SDK should create a default launch plan for a workflow.  This is a special-case to simplify
                         # authoring of workflows.
                         entity_to_module_key[o.create_launch_plan()] = (m, k)

--- a/flytekit/tools/module_loader.py
+++ b/flytekit/tools/module_loader.py
@@ -110,7 +110,7 @@ def iterate_registerable_entities_in_order(
             if isinstance(o, _registerable.RegisterableEntity):
                 if o.instantiated_in == m.__name__:
                     entity_to_module_key[o] = (m, k)
-                    if isinstance(o, _SdkWorkflow):
+                    if isinstance(o, _SdkWorkflow) and o.should_create_launch_plan:
                         # SDK should create a default launch plan for a workflow.  This is a special-case to simplify
                         # authoring of workflows.
                         entity_to_module_key[o.create_launch_plan()] = (m, k)

--- a/tests/flytekit/unit/common_tests/test_workflow.py
+++ b/tests/flytekit/unit/common_tests/test_workflow.py
@@ -137,6 +137,8 @@ def test_workflow_decorator():
         my_workflow, on_failure=_workflow_models.WorkflowMetadata.OnFailurePolicy.FAIL_AFTER_EXECUTABLE_NODES_COMPLETE,
     )
 
+    assert w.should_create_default_launch_plan == True
+
     assert w.interface.inputs["input_1"].type == primitives.Integer.to_flyte_literal_type()
     assert w.interface.inputs["input_2"].type == primitives.Integer.to_flyte_literal_type()
     assert w.nodes[0].inputs[0].var == "a"
@@ -353,3 +355,15 @@ def test_workflow_serialization():
     assert len(serialized.template.nodes) == 6
     assert len(serialized.template.interface.inputs.variables.keys()) == 2
     assert len(serialized.template.interface.outputs.variables.keys()) == 2
+
+
+def test_workflow_disable_default_launch_plan():
+    class MyWorkflow(object):
+        input_1 = promise.Input("input_1", primitives.Integer)
+        input_2 = promise.Input("input_2", primitives.Integer, default=5, help="Not required.")
+
+    w = workflow.build_sdk_workflow_from_metaclass(
+        MyWorkflow, disable_default_launch_plan=True,
+    )
+
+    assert w.should_create_default_launch_plan == False

--- a/tests/flytekit/unit/common_tests/test_workflow.py
+++ b/tests/flytekit/unit/common_tests/test_workflow.py
@@ -137,7 +137,7 @@ def test_workflow_decorator():
         my_workflow, on_failure=_workflow_models.WorkflowMetadata.OnFailurePolicy.FAIL_AFTER_EXECUTABLE_NODES_COMPLETE,
     )
 
-    assert w.should_create_default_launch_plan == True
+    assert w.should_create_default_launch_plan is True
 
     assert w.interface.inputs["input_1"].type == primitives.Integer.to_flyte_literal_type()
     assert w.interface.inputs["input_2"].type == primitives.Integer.to_flyte_literal_type()
@@ -362,8 +362,6 @@ def test_workflow_disable_default_launch_plan():
         input_1 = promise.Input("input_1", primitives.Integer)
         input_2 = promise.Input("input_2", primitives.Integer, default=5, help="Not required.")
 
-    w = workflow.build_sdk_workflow_from_metaclass(
-        MyWorkflow, disable_default_launch_plan=True,
-    )
+    w = workflow.build_sdk_workflow_from_metaclass(MyWorkflow, disable_default_launch_plan=True,)
 
-    assert w.should_create_default_launch_plan == False
+    assert w.should_create_default_launch_plan is False


### PR DESCRIPTION
# TL;DR
Adds a flag to control whether a default launchplan should be generated for the workflow at registration time. The default behavior is to do so.

E.g.
```
@workflow_class(disable_default_launch_plan=True)
def MyWorkflow():
   ...

my_lp = MyWorkflow.create_launch_plan(...)

#my_lp will be the only launchplan created for this workflow
```

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Tracking Issue
https://github.com/lyft/flyte/issues/462
