### PR TITLE
Remove double-iteration (legacy code fix)

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 import flytekit.plugins  # noqa: F401
 
-__version__ = "0.12.6"
+__version__ = "0.12.7"

--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -30,9 +30,7 @@ def register_all(project, domain, pkgs, test, version):
         name = _utils.fqdn(m.__name__, k, entity_type=o.resource_type)
         _logging.debug("Found module {}\n   K: {} Instantiated in {}".format(m, k, o._instantiated_in))
         o._id = _identifier.Identifier(o.resource_type, project, domain, name, version)
-        loaded_entities.append(o)
 
-    for o in loaded_entities:
         if test:
             click.echo("Would register {:20} {}".format("{}:".format(o.entity_type_text), o.id.name))
         else:

--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -25,7 +25,6 @@ def register_all(project, domain, pkgs, test, version):
     # m = module (i.e. python file)
     # k = value of dir(m), type str
     # o = object (e.g. SdkWorkflow)
-    loaded_entities = []
     for m, k, o in iterate_registerable_entities_in_order(pkgs):
         name = _utils.fqdn(m.__name__, k, entity_type=o.resource_type)
         _logging.debug("Found module {}\n   K: {} Instantiated in {}".format(m, k, o._instantiated_in))


### PR DESCRIPTION
# TL;DR
This code doesn't fix any issue here, but addresses an issue with an internal Lyft library that allows this open-source code to interact with Lyft internal systems.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Iterating through the list of objects that need to be registered twice triggers the incorrect register call.  Since the double-iteration was just used for logging, we can just remove it.

## Tracking Issue
NA

## Follow-up issue
NA
