### PR TITLE
Incorrect error formatting

### DIFF
--- a/flytekit/interfaces/data/s3/s3proxy.py
+++ b/flytekit/interfaces/data/s3/s3proxy.py
@@ -42,7 +42,7 @@ def _update_cmd_config_and_execute(cmd: List[str]):
     try:
         return _subprocess.check_call(cmd, env=env)
     except Exception as e:
-        logging.error("Exception when trying to execute {}, reason: {}".format(cmd, str(e)))
+        logging.error(f"Exception when trying to execute {cmd}, reason: {str(e)}")
         retry += 1
         if retry > _aws_config.RETRIES:
             raise

--- a/flytekit/interfaces/data/s3/s3proxy.py
+++ b/flytekit/interfaces/data/s3/s3proxy.py
@@ -42,7 +42,7 @@ def _update_cmd_config_and_execute(cmd: List[str]):
     try:
         return _subprocess.check_call(cmd, env=env)
     except Exception as e:
-        logging.error("Exception when trying to execute {}, reason: {}", cmd, str(e))
+        logging.error("Exception when trying to execute {}, reason: {}".format(cmd, str(e)))
         retry += 1
         if retry > _aws_config.RETRIES:
             raise


### PR DESCRIPTION
# TL;DR
This patch fixes incorrect error message formatting while retrying failed AWS CLI command (it uses unsupported ```{}``` syntax). Switched to ```format``` method.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue
