### PR TITLE
Spark Configuration can be dynamically updated or overriden

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,7 +2,7 @@ import logging as _logging
 
 import flytekit.plugins  # noqa: F401
 
-__version__ = "0.13.0b8"
+__version__ = "0.13.0b9"
 
 logger = _logging.getLogger("flytekit")
 

--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,7 +2,7 @@ import logging as _logging
 
 import flytekit.plugins  # noqa: F401
 
-__version__ = "0.13.0b7"
+__version__ = "0.13.0b8"
 
 logger = _logging.getLogger("flytekit")
 

--- a/flytekit/common/mixins/registerable.py
+++ b/flytekit/common/mixins/registerable.py
@@ -83,6 +83,9 @@ class TrackableEntity(FlyteEntity, metaclass=_InstanceTracker):
         """
         return self._platform_valid_name
 
+    def assign_name(self, name):
+        self._platform_valid_name = name
+
     def auto_assign_name(self):
         """
         This function is a bit of trickster Python code that goes hand in hand with the _InstanceTracker metaclass

--- a/flytekit/common/tasks/sdk_runnable.py
+++ b/flytekit/common/tasks/sdk_runnable.py
@@ -222,7 +222,6 @@ class SdkRunnableTask(_base_task.SdkTask, metaclass=_sdk_bases.ExtendedSdkType):
         timeout,
         environment,
         custom,
-        copy=False,
     ):
         """
         :param task_function: Function container user code.  This will be executed via the SDK's engine.
@@ -243,7 +242,6 @@ class SdkRunnableTask(_base_task.SdkTask, metaclass=_sdk_bases.ExtendedSdkType):
         :param datetime.timedelta timeout:
         :param dict[Text, Text] environment:
         :param dict[Text, T] custom:
-        :param bool copy: Indicates if this is a copy function, in this case the name will be prefixed with a hash
         """
         self._task_function = task_function
         super(SdkRunnableTask, self).__init__(

--- a/flytekit/common/tasks/sdk_runnable.py
+++ b/flytekit/common/tasks/sdk_runnable.py
@@ -222,6 +222,7 @@ class SdkRunnableTask(_base_task.SdkTask, metaclass=_sdk_bases.ExtendedSdkType):
         timeout,
         environment,
         custom,
+        copy=False,
     ):
         """
         :param task_function: Function container user code.  This will be executed via the SDK's engine.
@@ -242,6 +243,7 @@ class SdkRunnableTask(_base_task.SdkTask, metaclass=_sdk_bases.ExtendedSdkType):
         :param datetime.timedelta timeout:
         :param dict[Text, Text] environment:
         :param dict[Text, T] custom:
+        :param bool copy: Indicates if this is a copy function, in this case the name will be prefixed with a hash
         """
         self._task_function = task_function
         super(SdkRunnableTask, self).__init__(

--- a/flytekit/common/tasks/spark_task.py
+++ b/flytekit/common/tasks/spark_task.py
@@ -5,6 +5,9 @@ try:
 except ImportError:
     from inspect import getargspec as _getargspec
 
+import copy as _copy
+import hashlib as _hashlib
+import json as _json
 import os as _os
 import sys as _sys
 
@@ -20,9 +23,6 @@ from flytekit.common.types import helpers as _type_helpers
 from flytekit.models import literals as _literal_models
 from flytekit.models import task as _task_models
 from flytekit.plugins import pyspark as _pyspark
-import hashlib as _hashlib
-import json as _json
-import copy as _copy
 
 
 class GlobalSparkContext(object):

--- a/flytekit/common/tasks/spark_task.py
+++ b/flytekit/common/tasks/spark_task.py
@@ -170,8 +170,9 @@ class SdkSparkTask(_sdk_runnable.SdkRunnableTask):
         # Trim off first two parameters as they are reserved for workflow_parameters and spark_context
         return set(_getargspec(self.task_function).args[2:])
 
-    def with_conf(self, new_spark_conf: typing.Dict[str, str] = None,
-                  new_hadoop_conf: typing.Dict[str, str] = None):
+    def with_overrides(self,
+                       new_spark_conf: typing.Dict[str, str] = None,
+                       new_hadoop_conf: typing.Dict[str, str] = None):
         """
         Creates a new SparkJob instance with the modified configuration or timeouts
         """
@@ -180,9 +181,6 @@ class SdkSparkTask(_sdk_runnable.SdkRunnableTask):
 
         if not new_hadoop_conf:
             new_hadoop_conf = self._spark_job.hadoop_conf
-
-        updates = {"spark": new_spark_conf, "hadoop": new_hadoop_conf}
-        salt = _hashlib.md5(_json.dumps(updates, sort_keys=True).encode("utf-8")).hexdigest()
 
         tk = SdkSparkTask(
             task_function=self.task_function,
@@ -199,6 +197,7 @@ class SdkSparkTask(_sdk_runnable.SdkRunnableTask):
             environment=self._container.env,
         )
 
+        salt = _hashlib.md5(_json.dumps(tk.custom, sort_keys=True).encode("utf-8")).hexdigest()
         tk._id._name = "{}-{}".format(self._id.name, salt)
 
         return tk

--- a/flytekit/common/tasks/spark_task.py
+++ b/flytekit/common/tasks/spark_task.py
@@ -58,19 +58,19 @@ class SdkSparkTask(_sdk_runnable.SdkRunnableTask):
     """
 
     def __init__(
-            self,
-            task_function,
-            task_type,
-            discovery_version,
-            retries,
-            interruptible,
-            deprecated,
-            discoverable,
-            timeout,
-            spark_type,
-            spark_conf,
-            hadoop_conf,
-            environment,
+        self,
+        task_function,
+        task_type,
+        discovery_version,
+        retries,
+        interruptible,
+        deprecated,
+        discoverable,
+        timeout,
+        spark_type,
+        spark_conf,
+        hadoop_conf,
+        environment,
     ):
         """
         :param task_function: Function container user code.  This will be executed via the SDK's engine.
@@ -170,9 +170,9 @@ class SdkSparkTask(_sdk_runnable.SdkRunnableTask):
         # Trim off first two parameters as they are reserved for workflow_parameters and spark_context
         return set(_getargspec(self.task_function).args[2:])
 
-    def with_overrides(self,
-                       new_spark_conf: typing.Dict[str, str] = None,
-                       new_hadoop_conf: typing.Dict[str, str] = None):
+    def with_overrides(
+        self, new_spark_conf: typing.Dict[str, str] = None, new_hadoop_conf: typing.Dict[str, str] = None
+    ):
         """
         Creates a new SparkJob instance with the modified configuration or timeouts
         """

--- a/flytekit/common/tasks/spark_task.py
+++ b/flytekit/common/tasks/spark_task.py
@@ -183,5 +183,7 @@ class SdkSparkTask(_sdk_runnable.SdkRunnableTask):
 
         salt = _hashlib.md5(_json.dumps(tk.custom, sort_keys=True).encode("utf-8")).hexdigest()
         tk._id._name = "{}-{}".format(self._id.name, salt)
+        # We are overriding the platform name creation to prevent problems in dynamic
+        tk.assign_name(tk._id._name)
 
         return tk

--- a/flytekit/engines/unit/engine.py
+++ b/flytekit/engines/unit/engine.py
@@ -192,6 +192,11 @@ class DynamicTask(ReturnOutputsTask):
                 task = tasks_map[future_node.task_node.reference_id]
                 if task.type == _sdk_constants.SdkTaskType.CONTAINER_ARRAY_TASK:
                     sub_task_output = DynamicTask.execute_array_task(future_node.id, task, results)
+                elif task.type == _sdk_constants.SdkTaskType.SPARK_TASK:
+                    # This is required because `_transform_for_user_output` function about is invoked which
+                    # checks for outputs
+                    self._has_workflow_node = True
+                    return results
                 elif task.type == _sdk_constants.SdkTaskType.HIVE_JOB:
                     # TODO: futures.outputs should have the Schema instances.
                     # After schema is implemented, fill out random data into the random locations

--- a/flytekit/models/task.py
+++ b/flytekit/models/task.py
@@ -1,7 +1,7 @@
 import json as _json
+import typing
 
 import six as _six
-import typing
 from flyteidl.admin import task_pb2 as _admin_task
 from flyteidl.core import compiler_pb2 as _compiler
 from flyteidl.core import literals_pb2 as _literals_pb2

--- a/flytekit/models/task.py
+++ b/flytekit/models/task.py
@@ -1,6 +1,7 @@
 import json as _json
 
 import six as _six
+import typing
 from flyteidl.admin import task_pb2 as _admin_task
 from flyteidl.core import compiler_pb2 as _compiler
 from flyteidl.core import literals_pb2 as _literals_pb2
@@ -537,6 +538,24 @@ class SparkJob(_common.FlyteIdlEntity):
         self._executor_path = executor_path
         self._spark_conf = spark_conf
         self._hadoop_conf = hadoop_conf
+
+    def with_overrides(
+        self, new_spark_conf: typing.Dict[str, str] = None, new_hadoop_conf: typing.Dict[str, str] = None
+    ) -> "SparkJob":
+        if not new_spark_conf:
+            new_spark_conf = self.spark_conf
+
+        if not new_hadoop_conf:
+            new_hadoop_conf = self.hadoop_conf
+
+        return SparkJob(
+            spark_type=self.spark_type,
+            application_file=self.application_file,
+            main_class=self.main_class,
+            spark_conf=new_spark_conf,
+            hadoop_conf=new_hadoop_conf,
+            executor_path=self.executor_path,
+        )
 
     @property
     def main_class(self):

--- a/tests/flytekit/unit/models/test_dynamic_spark.py
+++ b/tests/flytekit/unit/models/test_dynamic_spark.py
@@ -1,5 +1,5 @@
-from flytekit.configuration import TemporaryConfiguration
 from flytekit.common import constants as _sdk_constants
+from flytekit.configuration import TemporaryConfiguration
 from flytekit.sdk import tasks as _tasks
 from flytekit.sdk.types import Types as _Types
 

--- a/tests/flytekit/unit/models/test_dynamic_spark.py
+++ b/tests/flytekit/unit/models/test_dynamic_spark.py
@@ -1,4 +1,4 @@
-from configuration import TemporaryConfiguration
+from flytekit.configuration import TemporaryConfiguration
 from flytekit.common import constants as _sdk_constants
 from flytekit.sdk import tasks as _tasks
 from flytekit.sdk.types import Types as _Types

--- a/tests/flytekit/unit/models/test_dynamic_spark.py
+++ b/tests/flytekit/unit/models/test_dynamic_spark.py
@@ -1,7 +1,6 @@
 from configuration import TemporaryConfiguration
 from flytekit.common import constants as _sdk_constants
 from flytekit.sdk import tasks as _tasks
-from flytekit.sdk import workflow as _workflow
 from flytekit.sdk.types import Types as _Types
 
 

--- a/tests/flytekit/unit/models/test_dynamic_spark.py
+++ b/tests/flytekit/unit/models/test_dynamic_spark.py
@@ -1,0 +1,30 @@
+from configuration import TemporaryConfiguration
+from flytekit.common import constants as _sdk_constants
+from flytekit.sdk import tasks as _tasks
+from flytekit.sdk import workflow as _workflow
+from flytekit.sdk.types import Types as _Types
+
+
+@_tasks.outputs(o=_Types.Integer)
+@_tasks.inputs(i=_Types.Integer)
+@_tasks.spark_task(spark_conf={"x": "y"})
+def my_spark_task(ctx, sc, i, o):
+    pass
+
+
+@_tasks.inputs(num=_Types.Integer)
+@_tasks.outputs(out=_Types.Integer)
+@_tasks.dynamic_task
+def spark_yield_task(wf_params, num, out):
+    wf_params.logging.info("Running inner task... yielding a launchplan")
+    t = my_spark_task.with_overrides(new_spark_conf={"a": "b"})
+    o = t(i=num)
+    yield o
+    out.set(o.outputs.o)
+
+
+def test_spark_yield():
+    with TemporaryConfiguration(None, internal_overrides={"image": "fakeimage"}):
+        outputs = spark_yield_task.unit_test(num=1)
+        dj_spec = outputs[_sdk_constants.FUTURES_FILE_NAME]
+        print(dj_spec)

--- a/tests/flytekit/unit/sdk/tasks/test_spark_task.py
+++ b/tests/flytekit/unit/sdk/tasks/test_spark_task.py
@@ -54,7 +54,7 @@ def test_default_python_task():
 def test_overrides_spark_task():
     assert default_task.id.name == "name"
     new_task = default_task.with_overrides(new_spark_conf={"x": "1"}, new_hadoop_conf={"y": "2"})
-    assert new_task.id.name == "name-8f7fab3cf6805e1cf8d340b981d83942"
+    assert new_task.id.name.startswith("name-")
     assert new_task.custom["sparkConf"]["x"] == "1"
     assert new_task.custom["hadoopConf"]["y"] == "2"
 

--- a/tests/flytekit/unit/sdk/tasks/test_spark_task.py
+++ b/tests/flytekit/unit/sdk/tasks/test_spark_task.py
@@ -53,8 +53,8 @@ def test_default_python_task():
 
 def test_overrides_spark_task():
     assert default_task.id.name == "name"
-    new_task = default_task.with_conf(new_spark_conf={"x": "1"}, new_hadoop_conf={"y": "2"})
-    assert new_task.id.name == "name-68e80c9654c8e336f82ad1c712a1371f"
+    new_task = default_task.with_overrides(new_spark_conf={"x": "1"}, new_hadoop_conf={"y": "2"})
+    assert new_task.id.name == "name-8f7fab3cf6805e1cf8d340b981d83942"
     assert new_task.custom["sparkConf"]["x"] == "1"
     assert new_task.custom["hadoopConf"]["y"] == "2"
 
@@ -62,3 +62,6 @@ def test_overrides_spark_task():
     assert default_task.custom["hadoopConf"]["C"] == "D"
 
     assert default_task.__hash__() != new_task.__hash__()
+
+    new_task2 = default_task.with_overrides(new_spark_conf={"x": "1"}, new_hadoop_conf={"y": "2"})
+    assert new_task2.id.name == new_task.id.name

--- a/tests/flytekit/unit/sdk/tasks/test_spark_task.py
+++ b/tests/flytekit/unit/sdk/tasks/test_spark_task.py
@@ -62,6 +62,9 @@ def test_overrides_spark_task():
     assert default_task.custom["sparkConf"]["A"] == "B"
     assert default_task.custom["hadoopConf"]["C"] == "D"
 
+    assert default_task.has_valid_name is False
+    default_task.assign_name("my-task")
+    assert default_task.has_valid_name
     assert new_task.interface == default_task.interface
 
     assert default_task.__hash__() != new_task.__hash__()

--- a/tests/flytekit/unit/sdk/tasks/test_spark_task.py
+++ b/tests/flytekit/unit/sdk/tasks/test_spark_task.py
@@ -49,3 +49,16 @@ def test_default_python_task():
     pb2 = default_task.to_flyte_idl()
     assert pb2.custom["sparkConf"]["A"] == "B"
     assert pb2.custom["hadoopConf"]["C"] == "D"
+
+
+def test_overrides_spark_task():
+    assert default_task.id.name == "name"
+    new_task = default_task.with_conf(new_spark_conf={"x": "1"}, new_hadoop_conf={"y": "2"})
+    assert new_task.id.name == "name-68e80c9654c8e336f82ad1c712a1371f"
+    assert new_task.custom["sparkConf"]["x"] == "1"
+    assert new_task.custom["hadoopConf"]["y"] == "2"
+
+    assert default_task.custom["sparkConf"]["A"] == "B"
+    assert default_task.custom["hadoopConf"]["C"] == "D"
+
+    assert default_task.__hash__() != new_task.__hash__()

--- a/tests/flytekit/unit/sdk/tasks/test_spark_task.py
+++ b/tests/flytekit/unit/sdk/tasks/test_spark_task.py
@@ -16,7 +16,7 @@ from flytekit.sdk.types import Types
 @outputs(out1=Types.String)
 @spark_task(spark_conf={"A": "B"}, hadoop_conf={"C": "D"})
 def default_task(wf_params, sc, in1, out1):
-    pass
+    out1.set("hello")
 
 
 default_task._id = _identifier.Identifier(_identifier.ResourceType.TASK, "project", "domain", "name", "version")
@@ -54,6 +54,7 @@ def test_default_python_task():
 def test_overrides_spark_task():
     assert default_task.id.name == "name"
     new_task = default_task.with_overrides(new_spark_conf={"x": "1"}, new_hadoop_conf={"y": "2"})
+    assert isinstance(new_task, _spark_task.SdkSparkTask)
     assert new_task.id.name.startswith("name-")
     assert new_task.custom["sparkConf"]["x"] == "1"
     assert new_task.custom["hadoopConf"]["y"] == "2"
@@ -61,7 +62,12 @@ def test_overrides_spark_task():
     assert default_task.custom["sparkConf"]["A"] == "B"
     assert default_task.custom["hadoopConf"]["C"] == "D"
 
+    assert new_task.interface == default_task.interface
+
     assert default_task.__hash__() != new_task.__hash__()
 
     new_task2 = default_task.with_overrides(new_spark_conf={"x": "1"}, new_hadoop_conf={"y": "2"})
     assert new_task2.id.name == new_task.id.name
+
+    t = new_task(in1=1)
+    assert t.outputs["out1"] is not None


### PR DESCRIPTION
# TL;DR
A user can now easily override spark and hadoop conf using dynamic tasks or when registering a workflow. This does not solve overrides completely, but is step 1 towards it

```python
@spark_task(spark_conf={...}, hadoop_conf={...})
def foo(...):
  pass

@dynamic_task
def dynamic():
  t = foo.with_overrides(spark_conf={})()
  yield t
```
## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
SdkSparkTask has a special method called with_conf(...) that creates a new flyte task with the override configuration.

## Tracking Issue
https://github.com/lyft/flyte/issues/528

## Follow-up issue
_NA_
