### PR TITLE
SparkConf & HadoopConf are exposed

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,7 +2,7 @@ import logging as _logging
 
 import flytekit.plugins  # noqa: F401
 
-__version__ = "0.13.0b9"
+__version__ = "0.13.0b10"
 
 logger = _logging.getLogger("flytekit")
 

--- a/flytekit/common/tasks/spark_task.py
+++ b/flytekit/common/tasks/spark_task.py
@@ -161,6 +161,14 @@ class SdkSparkTask(_sdk_runnable.SdkRunnableTask):
             )
         }
 
+    @property
+    def spark_conf(self):
+        return self._spark_job.spark_conf
+
+    @property
+    def hadoop_conf(self):
+        return self._spark_job.hadoop_conf
+
     def _get_container_definition(self, **kwargs):
         """
         :rtype: SdkRunnableSparkContainer

--- a/tests/flytekit/unit/sdk/tasks/test_spark_task.py
+++ b/tests/flytekit/unit/sdk/tasks/test_spark_task.py
@@ -43,6 +43,8 @@ def test_default_python_task():
     assert len(default_task.container.resources.requests) == 0
     assert default_task.custom["sparkConf"]["A"] == "B"
     assert default_task.custom["hadoopConf"]["C"] == "D"
+    assert default_task.hadoop_conf["C"] == "D"
+    assert default_task.spark_conf["A"] == "B"
     assert _os.path.abspath(_entrypoint.__file__)[:-1] in default_task.custom["mainApplicationFile"]
     assert default_task.custom["executorPath"] == _sys.executable
 


### PR DESCRIPTION
# TL;DR
SparkConfig and HadoopConfig are available from the declared Flyte task

```python
@spark_task(spark_conf={"spark.driver.memory": "1g"}, hadoop_conf={"hadoop.s3committer":"x"})
def my_spark_task():
   pass

print(my_spark_task.spark_conf)
```
Result
```bash
{
    "spark.driver.memory": "1g",
}
```

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue


