### PR TITLE
Make --insecure and --host flags work when watching an execution.

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 import flytekit.plugins  # noqa: F401
 
-__version__ = "0.12.9"
+__version__ = "0.12.10"

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -1051,7 +1051,9 @@ def watch_execution(host, insecure, urn):
     execution = _workflow_execution_common.SdkWorkflowExecution.promote_from_model(client.get_execution(ex_id))
 
     _click.echo("Waiting for the execution {} to complete ...".format(_tt(execution.id)))
-    execution.wait_for_completion()
+
+    with _platform_config.URL.get_patcher(host), _platform_config.INSECURE.get_patcher(_tt(insecure)):
+        execution.wait_for_completion()
 
 
 @_flyte_cli.command("relaunch-execution", cls=_FlyteSubCommand)


### PR DESCRIPTION
# TL;DR

Port changes from https://github.com/lyft/flytekit/pull/191.

`-h/--host` flag does not get picked up for `watch-execution`:
```
> flyte-cli watch-execution -i -h localhost:51234 -u ex:sunflower-sandbox:default:f97312912bdfc476eab1
...
flytekit.common.exceptions.user.FlyteAssertion: No configuration set for [platform] url.  This is a required configuration.
```

`-i/--insecure` flag does not get picked up for `watch-execution`:
```
> FLYTE_PLATFORM_URL=localhost:51234 flyte-cli watch-execution -i -u ex:sunflower-sandbox:default:f37243487d6794178b76
...
E1003 02:24:42.122552000 4817231296 ssl_transport_security.cc:1439]    Handshake failed with fatal error SSL_ERROR_SSL: error:100000f7:SSL routines:OPENSSL_internal:WRONG_VERSION_NUMBER.
...
```

However, this works:
```
> FLYTE_PLATFORM_URL=localhost:51234 FLYTE_PLATFORM_INSECURE=true flyte-cli watch-execution -u ex:sunflower-sandbox:default:f97312912bdfc476eab1
```

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Correctly patch the `platform_config.URL` and `platform_config.INSECURE` values from CLI arguments for `flyte-cli watch-execution`

## Tracking Issue
_NA_

## Follow-up issue
_NA_
