### PR TITLE
[ignore] Annotations changes

### DIFF
--- a/flytekit/annotated/context_manager.py
+++ b/flytekit/annotated/context_manager.py
@@ -93,7 +93,6 @@ class FlyteContext(object):
         self._execution_state = execution_state
         self._flyte_client = flyte_client
         self._user_space_params = user_space_params
-        self._freeform_params = []
 
     def __enter__(self):
         # Should we auto-assign the parent here?
@@ -103,16 +102,6 @@ class FlyteContext(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         FlyteContext.OBJS.pop()
-
-    def add_compile_time_constant(self, val: Any, associated_var: _interface_models.Variable):
-        """
-        These are constant values within the context of the workflow compilation or execution (only in the case of
-        dynamic workflows), for e.g.
-         task(a=x, b="some value")
-         here b is associated with a default constant that is bound at the compilation time of the workflow
-        We will refer to them as freeform parameters
-        """
-        self._freeform_params.append((val, associated_var))
 
     @classmethod
     def current_context(cls) -> 'FlyteContext':

--- a/flytekit/annotated/interface.py
+++ b/flytekit/annotated/interface.py
@@ -5,7 +5,6 @@ from typing import Dict, Generator, Union, Type, Tuple, List, Any, _GenericAlias
 
 from flytekit import logger
 from flytekit.annotated import type_engine
-from flytekit.common import interface as _common_interface
 from flytekit.models import interface as _interface_models, types as _type_models
 
 
@@ -103,7 +102,7 @@ def transform_inputs_to_parameters(interface: Interface) -> _interface_models.Pa
     return _interface_models.ParameterMap(params)
 
 
-def transform_interface_to_typed_interface(interface: Interface) -> _common_interface.TypedInterface:
+def transform_interface_to_typed_interface(interface: Interface) -> _interface_models.TypedInterface:
     """
     Transform the given simple python native interface to FlyteIDL's interface
     """
@@ -112,10 +111,7 @@ def transform_interface_to_typed_interface(interface: Interface) -> _common_inte
 
     inputs_map = transform_variable_map(interface.inputs)
     outputs_map = transform_variable_map(interface.outputs)
-    interface_model = _interface_models.TypedInterface(inputs_map, outputs_map)
-
-    # Maybe in the future we can just use the model
-    return _common_interface.TypedInterface.promote_from_model(interface_model)
+    return _interface_models.TypedInterface(inputs_map, outputs_map)
 
 
 def transform_variable_map_to_collection(
@@ -144,14 +140,15 @@ def transform_variable_map_to_collection(
 
 
 def transform_typed_interface_to_collection_interface(
-        interface: _common_interface.TypedInterface) -> _common_interface.TypedInterface:
+        interface: _interface_models.TypedInterface) -> _interface_models.TypedInterface:
     """
     Takes a single task interface and interpolates it to an array interface - to allow performing distributed python map
     like functions
     """
     map_inputs = transform_variable_map_to_collection(interface.inputs)
     map_outputs = transform_variable_map_to_collection(interface.outputs)
-    return _common_interface.TypedInterface(inputs=map_inputs, outputs=map_outputs)
+
+    return _interface_models.TypedInterface(inputs=map_inputs, outputs=map_outputs)
 
 
 def transform_signature_to_interface(signature: inspect.Signature) -> Interface:

--- a/flytekit/annotated/promise.py
+++ b/flytekit/annotated/promise.py
@@ -35,6 +35,8 @@ def translate_inputs_to_literals(ctx, input_kwargs: Dict[str, Any], interface: _
     return input_kwargs
 
 
+# TODO: The NodeOutput object, which this Promise wraps, has an sdk_type. Since we're no longer using sdk types,
+#  we should consider adding a literal type to this object as well for downstream checking when Bindings are created.
 class Promise(object):
     def __init__(self, var: str, val: Union[_NodeOutput, _literal_models.Literal]):
         self._var = var

--- a/flytekit/annotated/promise.py
+++ b/flytekit/annotated/promise.py
@@ -1,8 +1,38 @@
 import collections
-from typing import Union, Tuple, List
+from typing import Union, Dict, Any, List, Tuple
 
+from flytekit import engine as flytekit_engine
 from flytekit.common.promise import NodeOutput as _NodeOutput
-from flytekit.models import literals as _literal_models
+from flytekit.models import literals as _literal_models, interface as _interface_models
+
+
+def translate_inputs_to_literals(ctx, input_kwargs: Dict[str, Any], interface: _interface_models.TypedInterface):
+    """
+    When calling a task inside a workflow, a user might do something like this.
+
+    def my_wf(in1: int) -> int:
+        a = task_1(in1=in1)
+        b = task_2(in1=5, in2=a)
+        return b
+
+    If this is the case, when task_2 is called in local workflow execution, we'll need to translate the Python native
+    literal 5 to a Flyte literal.
+    """
+    # TODO: Are there any pass-by-reference considerations we need to think about?  I don't think so. Write unit
+    #  tests to be sure.
+    for k, v in input_kwargs.items():
+        if k not in interface.inputs:
+            raise ValueError(f"Received unexpected keyword argument {k}")
+        # In the example above, this handles the "in2=a" type of argument
+        if isinstance(v, Promise):
+            input_kwargs[k] = v.val
+        # This handles native values, the 5 example
+        else:
+            val = input_kwargs[k]
+            var = interface.inputs[k]
+            input_kwargs[k] = flytekit_engine.python_value_to_idl_literal(ctx, val, var.type)
+
+    return input_kwargs
 
 
 class Promise(object):

--- a/flytekit/annotated/task.py
+++ b/flytekit/annotated/task.py
@@ -10,12 +10,12 @@ from flytekit import engine as flytekit_engine, logger
 from flytekit.annotated.context_manager import ExecutionState, FlyteContext
 from flytekit.annotated.interface import Interface, transform_interface_to_typed_interface, \
     transform_signature_to_interface, transform_typed_interface_to_collection_interface
-from flytekit.annotated.promise import Promise, create_task_output
+from flytekit.annotated.promise import Promise, create_task_output, translate_inputs_to_literals
 from flytekit.annotated.workflow import Workflow
-from flytekit.common import nodes as _nodes, interface as _common_interface
+from flytekit.common import nodes as _nodes
 from flytekit.common.exceptions import user as _user_exceptions
 from flytekit.common.promise import NodeOutput as _NodeOutput
-from flytekit.models import task as _task_model, literals as _literal_models
+from flytekit.models import task as _task_model, literals as _literal_models, interface as _interface_models
 from flytekit.models.core import workflow as _workflow_model, identifier as _identifier_model
 
 
@@ -31,7 +31,7 @@ from flytekit.models.core import workflow as _workflow_model, identifier as _ide
 # already.)
 class Task(object):
 
-    def __init__(self, name: str, interface: _common_interface.TypedInterface, metadata: _task_model.TaskMetadata,
+    def __init__(self, name: str, interface: _interface_models.TypedInterface, metadata: _task_model.TaskMetadata,
                  *args, **kwargs):
         self._name = name
         self._interface = interface
@@ -93,23 +93,7 @@ class Task(object):
         For regular execution, dispatch_execute is invoked directly.
         """
         # Unwrap the kwargs values. After this, we essentially have a LiteralMap
-        for k, v in kwargs.items():
-            if k not in self.interface.inputs:
-                # Should we do this in strict mode?
-                raise ValueError(f"Received unexpected keyword argument {k}")
-            if isinstance(v, Promise):
-                if not v.is_ready:
-                    raise BrokenPipeError(
-                        f"Expected an actual value from the previous step, but received an incomplete promise {v}")
-                kwargs[k] = v.val
-            else:
-                # Assume its a native value. Lets convert it to a literal and also add it to the context as a freeform
-                # parameter
-                val = kwargs[k]
-                var = self.interface.inputs[k]
-                ctx.add_compile_time_constant(val, var)
-                kwargs[k] = flytekit_engine.python_value_to_idl_literal(ctx, val, var.type)
-
+        kwargs = translate_inputs_to_literals(ctx, input_kwargs=kwargs, interface=self.interface)
         input_literal_map = _literal_models.LiteralMap(literals=kwargs)
 
         outputs_literal_map = self.dispatch_execute(ctx, input_literal_map)
@@ -117,9 +101,8 @@ class Task(object):
 
         # TODO maybe this is the part that should be done for local execution, we pass the outputs to some special
         #    location, otherwise we dont really need to right? The higher level execute could just handle literalMap
-        # After running, we again have to wrap the outputs, if any, back into NodeOutput objects
+        # After running, we again have to wrap the outputs, if any, back into Promise objects
         output_names = list(self.interface.outputs.keys())
-        node_results = []
         if len(output_names) != len(outputs_literals):
             # Length check, clean up exception
             raise Exception(f"Length difference {len(output_names)} {len(outputs_literals)}")
@@ -130,14 +113,15 @@ class Task(object):
     def dispatch_execute(
             self, ctx: FlyteContext, input_literal_map: _literal_models.LiteralMap) -> _literal_models.LiteralMap:
         """
-        This method translates Flytes native Type system based inputs and dispatches the actual call to the executor
-        NOTE: This method is also invoked during runtime
+        This method translates Flyte's Type system based input values and invokes the actual call to the executor
+        This method is also invoked during runtime.
         """
+
         # Translate the input literals to Python native
         native_inputs = flytekit_engine.idl_literal_map_to_python_value(ctx, input_literal_map)
 
-        # TODO Logger should auto inject the current context information to indicate if the task is running within
-        # a workflow or a subworkflow etc
+        # TODO: Logger should auto inject the current context information to indicate if the task is running within
+        #   a workflow or a subworkflow etc
         logger.info(f"Invoking {self.name} with inputs: {native_inputs}")
         try:
             native_outputs = self.execute(**native_inputs)
@@ -196,7 +180,7 @@ class Task(object):
             return self.execute(**kwargs)
 
     @property
-    def interface(self) -> _common_interface.TypedInterface:
+    def interface(self) -> _interface_models.TypedInterface:
         return self._interface
 
     @property

--- a/flytekit/annotated/task.py
+++ b/flytekit/annotated/task.py
@@ -330,7 +330,22 @@ class DynamicWorkflowTask(Task):
         super().__init__(self._workflow.name, self._workflow.interface, metadata, *args, **kwargs)
 
     def execute(self, **kwargs) -> Any:
+        """
+        By the time this function is invoked, the _local_execute function should have unwrapped the Promises and Flyte
+        literal wrappers so that the kwargs we are working with here are now Python native literal values. This
+        function is also expected to return Python native literal values.
+
+        Since the user code within a dynamic task constitute a workflow, we have to first compile the workflow, and
+        then execute that workflow.
+
+        When running for real in production, the task would stop after the compilation step, and then create a file
+        representing that newly generated workflow, instead of executing it.
+        """
         ctx = FlyteContext.current_context()
+        # with ctx.new_compilation_context() as ctx:
+        # if ctx.execution_state and ctx.execution_state.mode == ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION:
+        #     ...
+
         if ctx.compilation_state is not None:
             raise NotImplementedError(
                 "Dynamic workflow compilation is not yet implemented. This will be invoked at runtime")

--- a/flytekit/annotated/task.py
+++ b/flytekit/annotated/task.py
@@ -39,7 +39,7 @@ class Task(object):
 
     def _compile(self, ctx: FlyteContext, *args, **kwargs):
         """
-        This method is used to compile a task and generate nodes with bindings. This is not used in the execution path
+        This method is used to generate a node with bindings. This is not used in the execution path.
         """
         used_inputs = set()
         bindings = []
@@ -60,7 +60,7 @@ class Task(object):
             )
 
         # Detect upstream nodes
-        upstream_nodes = [input_val.sdk_node for input_val in kwargs.values() if isinstance(input_val, _NodeOutput)]
+        upstream_nodes = [input_val.ref.sdk_node for input_val in kwargs.values() if isinstance(input_val, Promise)]
 
         # TODO: Make the metadata name the full name of the (function)?
         sdk_node = _nodes.SdkNode(

--- a/flytekit/annotated/workflow.py
+++ b/flytekit/annotated/workflow.py
@@ -153,6 +153,9 @@ class Workflow(object):
         # there, but it'll return Promise objects.
         else:
             # Run some sanity checks
+            # Even though the _local_execute call generally expects inputs to be Promises, we don't have to do the
+            # conversion here in this loop. The reason is because we don't prevent users from specifying inputs
+            # as direct scalars, which means there's another Promise-generating loop inside _local_execute too
             for k, v in kwargs.items():
                 if k not in self.interface.inputs:
                     raise ValueError(f"Received unexpected keyword argument {k}")

--- a/flytekit/annotated/workflow.py
+++ b/flytekit/annotated/workflow.py
@@ -1,15 +1,19 @@
 import inspect
-from typing import Dict, Any, Callable
+import datetime
+from typing import Dict, Any, Callable, Union, Tuple
 
 from flytekit import engine as flytekit_engine, logger
 from flytekit.annotated.context_manager import FlyteContext, ExecutionState
 from flytekit.annotated.interface import transform_signature_to_interface, transform_interface_to_typed_interface, \
     transform_inputs_to_parameters
-from flytekit.annotated.promise import Promise
+from flytekit.annotated.promise import Promise, create_task_output
 from flytekit.common import constants as _common_constants
 from flytekit.common.workflow import SdkWorkflow as _SdkWorkflow
 from flytekit.models import literals as _literal_models, types as _type_models
-from flytekit.models.core import identifier as _identifier_model
+from flytekit.models.core import identifier as _identifier_model, workflow as _workflow_model
+from flytekit.common.exceptions import user as _user_exceptions
+from flytekit.common import nodes as _nodes
+from flytekit.common import promise as _common_promise
 
 
 class Workflow(object):
@@ -92,71 +96,135 @@ class Workflow(object):
             return bindings[0]
         return tuple(bindings)
 
-    def _local_execute(self, ctx: FlyteContext, nested=False, **kwargs) -> Dict[str, Any]:
+    def _local_execute(self, ctx: FlyteContext, **kwargs) -> Union[Tuple[Promise], Promise, None]:
         """
-        Performs local execution of a workflow
+        Performs local execution of a workflow. kwargs are expected to be Promises for the most part (unless,
+        someone has hardcoded in my_wf(input_1=5) or something).
         :param ctx: The FlyteContext
         :param nested: boolean that indicates if this is a nested workflow execution (subworkflow)
         :param kwargs: parameters for the workflow itself
         """
-        logger.info(f"Executing Workflow {self._name} with nested={nested}, ctx{ctx.execution_state.Mode}")
-        # NOTE: All inputs received by Workflow in this mode should be Promises.
-        # TODO, how will this work for dynamic workflow? Ideally dynamic workflow should use dispatch_execute
-        for k, v in kwargs.items():
-            if isinstance(v, Promise):
-                if not v.is_ready:
-                    raise BrokenPipeError(
-                        f"Expected an actual value from the previous step, but received an incomplete promise {v}")
+        logger.info(f"Executing Workflow {self._name}, ctx{ctx.execution_state.Mode}")
 
-        # TODO: These are all assumed to be TaskCallOutput objects, but they can
-        #   be other things as well.  What if someone just returns 5? Should we disallow this?
+        # This is done to support the invariant that Workflow local executions always work with Promise objects
+        # holding Flyte literal values. Even in a wf, a user can call a sub-workflow with a Python native value.
+        for k, v in kwargs.items():
+            if not isinstance(v, Promise):
+                kwargs[k] = Promise(
+                    var=k, val=flytekit_engine.python_value_to_idl_literal(ctx, v, self.interface.inputs[k].type))
+
+        # TODO: function_outputs are all assumed to be Promise objects produced by task calls, but can they be
+        #   other things as well? What if someone just returns 5? Should we disallow this?
         function_outputs = self._workflow_function(**kwargs)
 
-        if nested:
-            # If this is a subworkflow it should return promises upstream - to parent workflow
-            logger.info(f"Executing subworkfow returning promises")
-            return function_outputs
+        output_names = list(self.interface.outputs.keys())
+        if len(output_names) != len(function_outputs):
+            # Length check, clean up exception
+            raise Exception(f"Length difference {len(output_names)} {len(function_outputs)}")
 
-        output_names = list(self._interface.outputs.keys())
-        output_literal_map = {}
-        # TODO Ketan fix this make it into a simple promise transformation
-        if len(output_names) > 1:
-            for idx, var_name in enumerate(output_names):
-                output_literal_map[var_name] = function_outputs[idx].val
-        elif len(output_names) == 1:
-            output_literal_map[output_names[0]] = function_outputs.val
-        else:
-            return None
-
-        return flytekit_engine.idl_literal_map_to_python_value(ctx, _literal_models.LiteralMap(
-            literals=output_literal_map))
+        # This recasts the Promises provided by the outputs of the workflow's tasks into the correct output names
+        # of the workflow itself
+        vals = [Promise(var=output_names[idx], val=function_outputs[idx].val) for idx, promise in
+                enumerate(function_outputs)]
+        return create_task_output(vals)
 
     def __call__(self, *args, **kwargs):
-
         if len(args) > 0:
             raise Exception('not allowed')
 
         ctx = FlyteContext.current_context()
-        # Reserved for when we have subworkflows
+
+        # Handle subworkflows in compilation
         if ctx.compilation_state is not None:
-            return self.compile()
+            return self._create_and_link_node(ctx, **kwargs)
+
         elif ctx.execution_state is not None and ctx.execution_state.mode == ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION:
-            print(f"{self._name} in local execution mode")
             # We are already in a local execution, just continue the execution context
-            return self._local_execute(ctx, nested=True, **kwargs)
+            return self._local_execute(ctx, **kwargs)
+
+        # When someone wants to run the workflow function locally. Assume that the inputs given are given as Python
+        # native values. _local_execute will always translate Python native literals to Flyte literals, so no worries
+        # there, but it'll return Promise objects.
         else:
-            # When someone wants to run the workflow function locally
+            # Run some sanity checks
+            for k, v in kwargs.items():
+                if k not in self.interface.inputs:
+                    raise ValueError(f"Received unexpected keyword argument {k}")
+                if isinstance(v, Promise):
+                    raise ValueError(
+                        f"Received a promise for a workflow call, when expecting a native value for {k}")
+
             with ctx.new_execution_context(mode=ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION) as ctx:
-                for k, v in kwargs.items():
-                    if k not in self._interface.inputs:
-                        # Should we do this in strict mode?
-                        raise ValueError(f"Received unexpected keyword argument {k}")
-                    if isinstance(v, Promise):
-                        raise ValueError(
-                            f"Received a promise for a workflow call, when expecting a native value for {k}")
-                    kwargs[k] = Promise(
-                        var=k, val=flytekit_engine.python_value_to_idl_literal(ctx, v, self._interface.inputs[k].type))
-                return self._local_execute(ctx, **kwargs)
+                result = self._local_execute(ctx, **kwargs)
+
+            if result is None:
+                return None
+
+            if isinstance(result, Promise):
+                literals = {result.var: result.val}
+            else:
+                literals = {}
+                for prom in result:
+                    if not isinstance(prom, Promise):
+                        raise Exception("should be promises")
+
+                    literals[prom.var] = prom.val
+
+            # unpack result
+            return flytekit_engine.idl_literal_map_to_python_value(ctx, _literal_models.LiteralMap(
+                literals=literals))
+
+    def _create_and_link_node(self, ctx: FlyteContext, *args, **kwargs):
+        """
+        This method is used to create a node representing a subworkflow call in a workflow. It should closely mirror
+        the _compile function found in Task.
+        """
+
+        # TODO: Add handling of defaults
+        used_inputs = set()
+        bindings = []
+
+        for k in sorted(self.interface.inputs):
+            var = self.interface.inputs[k]
+            if k not in kwargs:
+                raise _user_exceptions.FlyteAssertion(
+                    "Input was not specified for: {} of type {}".format(k, var.type)
+                )
+            bindings.append(flytekit_engine.binding_from_python_std(ctx, k, var.type, kwargs[k]))
+            used_inputs.add(k)
+
+        extra_inputs = used_inputs ^ set(kwargs.keys())
+        if len(extra_inputs) > 0:
+            raise _user_exceptions.FlyteAssertion(
+                "Too many inputs were specified for the interface.  Extra inputs were: {}".format(extra_inputs)
+            )
+
+        # Detect upstream nodes
+        upstream_nodes = [input_val.ref.sdk_node for input_val in kwargs.values() if isinstance(input_val, Promise)]
+
+        sdk_node = _nodes.SdkNode(
+            # TODO
+            id=f"node-{len(ctx.compilation_state.nodes)}",
+            metadata=_workflow_model.NodeMetadata(self._name, datetime.timedelta(),
+                                                   _literal_models.RetryStrategy(0)),
+            bindings=sorted(bindings, key=lambda b: b.var),
+            upstream_nodes=upstream_nodes,
+            sdk_workflow=self._sdk_workflow
+        )
+        ctx.compilation_state.nodes.append(sdk_node)
+
+        # Create a node output object for each output, they should all point to this node of course.
+        # TODO: Again, we need to be sure that we end up iterating through the output names in the correct order
+        #  investigate this and document here.
+        node_outputs = []
+        for output_name, output_var_model in self.interface.outputs.items():
+            # TODO: If node id gets updated later, we have to make sure to update the NodeOutput model's ID, which
+            #  is currently just a static str
+            node_outputs.append(
+                Promise(output_name, _common_promise.NodeOutput(sdk_node=sdk_node, sdk_type=None, var=output_name)))
+        # Don't print this, it'll crash cuz sdk_node._upstream_node_ids might be None, but idl code will break
+
+        return create_task_output(node_outputs)
 
 
 def workflow(_workflow_function=None):

--- a/flytekit/annotated/workflow.py
+++ b/flytekit/annotated/workflow.py
@@ -118,6 +118,12 @@ class Workflow(object):
         function_outputs = self._workflow_function(**kwargs)
 
         output_names = list(self.interface.outputs.keys())
+        if len(output_names) == 0:
+            if function_outputs is None:
+                return None
+            else:
+                raise Exception("something returned from wf but shouldn't have outputs")
+
         if len(output_names) != len(function_outputs):
             # Length check, clean up exception
             raise Exception(f"Length difference {len(output_names)} {len(function_outputs)}")

--- a/flytekit/engine.py
+++ b/flytekit/engine.py
@@ -188,8 +188,8 @@ def python_value_to_idl_literal(
         return _literals_models.Literal(map=_literals_models.LiteralMap(literals=idl_literals))
 
 
-def binding_from_python_std(ctx: _flyte_context.FlyteContext, var_name: str, expected_literal_type,
-                            t_value) -> _literals_models.Binding:
+def binding_data_from_python_std(ctx: _flyte_context.FlyteContext, expected_literal_type: _type_models.LiteralType,
+                                 t_value) -> _literals_models.BindingData:
     # This handles the case where the incoming value is a workflow-level input
     if isinstance(t_value, _type_models.OutputReference):
         binding_data = _literals_models.BindingData(promise=t_value)
@@ -199,10 +199,17 @@ def binding_from_python_std(ctx: _flyte_context.FlyteContext, var_name: str, exp
         if not t_value.is_ready:
             binding_data = _literals_models.BindingData(promise=t_value.ref)
 
-    elif isinstance(t_value, list) or isinstance(t_value, dict):
-        # I didn't really like the list implementation below so leaving both dict and list unimplemented for now
-        # When filling this part out, keep in mind detection of upstream nodes in task compilation will also need to
-        # be updated.
+    elif isinstance(t_value, list):
+        if expected_literal_type.collection_type is None:
+            raise Exception(f'this should be a list and it is not: {type(t_value)} vs {expected_literal_type}')
+
+        collection = _literals_models.BindingDataCollection(bindings=[
+            binding_data_from_python_std(ctx, expected_literal_type.collection_type, t)
+            for t in t_value])
+
+        binding_data = _literals_models.BindingData(collection=collection)
+
+    elif isinstance(t_value, dict):
         raise Exception("not yet handled - haytham will implement")
 
     # This is the scalar case - e.g. my_task(in1=5)
@@ -212,4 +219,10 @@ def binding_from_python_std(ctx: _flyte_context.FlyteContext, var_name: str, exp
         scalar = python_value_to_idl_literal(ctx, t_value, expected_literal_type).scalar
         binding_data = _literals_models.BindingData(scalar=scalar)
 
+    return binding_data
+
+
+def binding_from_python_std(ctx: _flyte_context.FlyteContext, var_name: str,
+                            expected_literal_type: _type_models.LiteralType, t_value) -> _literals_models.Binding:
+    binding_data = binding_data_from_python_std(ctx, expected_literal_type, t_value)
     return _literals_models.Binding(var=var_name, binding=binding_data)

--- a/flytekit/engine.py
+++ b/flytekit/engine.py
@@ -209,9 +209,6 @@ def binding_from_python_std(ctx: _flyte_context.FlyteContext, var_name: str, exp
     else:
         # Question: Haytham/Ketan - Is it okay for me to rely on the expected idl type, which comes from the task's
         #   interface, to derive the scalar value?
-        # Question: The context here is only used for complicated things like handling files. Should we
-        #   support this? Or should we try to make this function simpler and only allow users to create bindings to
-        #   simple scalars?
         scalar = python_value_to_idl_literal(ctx, t_value, expected_literal_type).scalar
         binding_data = _literals_models.BindingData(scalar=scalar)
 

--- a/flytekit/models/interface.py
+++ b/flytekit/models/interface.py
@@ -173,7 +173,7 @@ class Parameter(_common.FlyteIdlEntity):
         return self._default
 
     @property
-    def required(self):
+    def required(self) -> bool:
         """
         If True, this parameter must be specified.  There cannot be a default value.
         :rtype: bool

--- a/tests/flytekit/unit/use_scenarios/unit_testing/test_type_hints.py
+++ b/tests/flytekit/unit/use_scenarios/unit_testing/test_type_hints.py
@@ -317,35 +317,36 @@ def test_wf1_compile_time_constant_vars():
         'out_1': "hello This is my way",
     }
 
-# def test_wf1_with_dynamic():
-#     @task
-#     def t1(a: int) -> str:
-#         a = a + 2
-#         return "world-" + str(a)
-#
-#     @task
-#     def t2(a: str, b: str) -> str:
-#         return b + a
-#
-#     @dynamic
-#     def my_subwf(a: int) -> typing.List[str]:
-#         s = []
-#         for i in range(a):
-#             s.append(t1(a=i))
-#         return s
-#
-#     @workflow
-#     def my_wf(a: int, b: str) -> (str, typing.List[str]):
-#         x = t2(a=b, b=b)
-#         v = my_subwf(a=a)
-#         return x, v
-#
-#     v = 5
-#     x = my_wf(a=v, b="hello ")
-#     assert x == {
-#         'out_0': "hello hello ",
-#         'out_1': ["world-" + str(i) for i in range(2, v+2)],
-#     }
+
+def test_wf1_with_dynamic():
+    @task
+    def t1(a: int) -> str:
+        a = a + 2
+        return "world-" + str(a)
+
+    @task
+    def t2(a: str, b: str) -> str:
+        return b + a
+
+    @dynamic
+    def my_subwf(a: int) -> typing.List[str]:
+        s = []
+        for i in range(a):
+            s.append(t1(a=i))
+        return s
+
+    @workflow
+    def my_wf(a: int, b: str) -> (str, typing.List[str]):
+        x = t2(a=b, b=b)
+        v = my_subwf(a=a)
+        return x, v
+
+    v = 5
+    x = my_wf(a=v, b="hello ")
+    assert x == {
+        'out_0': "hello hello ",
+        'out_1': ["world-" + str(i) for i in range(2, v+2)],
+    }
 
 
 # TODO Add an example that shows how tuple fails and it should fail cleanly. As tuple types are not supported!

--- a/tests/flytekit/unit/use_scenarios/unit_testing/test_type_hints.py
+++ b/tests/flytekit/unit/use_scenarios/unit_testing/test_type_hints.py
@@ -348,6 +348,29 @@ def test_wf1_with_dynamic():
         'out_1': ["world-" + str(i) for i in range(2, v+2)],
     }
 
+    compiled_sub_wf = my_subwf.compile_into_workflow(a=5)
+    assert len(compiled_sub_wf._sdk_workflow.nodes) == 5
+
+
+def test_list_output():
+    @task
+    def t1(a: int) -> str:
+        a = a + 2
+        return "world-" + str(a)
+
+    @workflow
+    def lister() -> typing.List[str]:
+        s = []
+        # FYI: For users who happen to look at this, keep in mind this is only run once at compile time.
+        for i in range(10):
+            s.append(t1(a=i))
+        return s
+
+    assert len(lister._sdk_workflow.outputs) == 1
+    binding_data = lister._sdk_workflow.outputs[0].binding  # the property should be named binding_data
+    assert binding_data.collection is not None
+    assert len(binding_data.collection.bindings) ==  10
+
 
 # TODO Add an example that shows how tuple fails and it should fail cleanly. As tuple types are not supported!
 


### PR DESCRIPTION
Ignore unless you're ketan/haytham.

* Delete all the freeform param stuff
* Remove the fancier (original, on master) Interface object in favor of the straight model
* Factor out the loop that makes things into Promise objects
* Remove nested subwf execution arg
* Move transformation of wf outputs in local exec to the call function (search for "unpack result")
* Add SdkNode creation on subworkflow call
* Add list binding creation
* Change workflow binding to use the binding creator in the flytekit_engine file
* Allow workflow compile to be given native inputs
