### PR TITLE
[ignore] Annotations launch plans

### DIFF
--- a/flytekit/annotated/context_manager.py
+++ b/flytekit/annotated/context_manager.py
@@ -19,7 +19,16 @@ from flytekit.models.core import identifier as _identifier
 
 
 class RegistrationSettings(object):
-    def __init__(self, project: str, domain: str, version: str, image: str, env: Optional[Dict[str, str]], iam_role: Optional[str] = None, service_account: Optional[str] = None):
+    def __init__(
+        self,
+        project: str,
+        domain: str,
+        version: str,
+        image: str,
+        env: Optional[Dict[str, str]],
+        iam_role: Optional[str] = None,
+        service_account: Optional[str] = None,
+    ):
         self._project = project
         self._domain = domain
         self._version = version
@@ -49,11 +58,11 @@ class RegistrationSettings(object):
         return self._env
 
     @property
-    def iam_role(self)-> Optional[str]:
+    def iam_role(self) -> Optional[str]:
         return self._iam_role
 
     @property
-    def service_account(self)-> Optional[str]:
+    def service_account(self) -> Optional[str]:
         return self._service_account
 
 

--- a/flytekit/annotated/context_manager.py
+++ b/flytekit/annotated/context_manager.py
@@ -16,6 +16,7 @@ from flytekit.configuration import sdk as _sdk_config
 from flytekit.engines.unit import mock_stats as _mock_stats
 from flytekit.interfaces.data import data_proxy as _data_proxy
 from flytekit.models.core import identifier as _identifier
+from flytekit.models.common import RawOutputDataConfig
 
 
 class RegistrationSettings(object):
@@ -28,6 +29,7 @@ class RegistrationSettings(object):
         env: Optional[Dict[str, str]],
         iam_role: Optional[str] = None,
         service_account: Optional[str] = None,
+        raw_output_data_config: Optional[str] = None,
     ):
         self._project = project
         self._domain = domain
@@ -36,6 +38,7 @@ class RegistrationSettings(object):
         self._env = env or {}
         self._iam_role = iam_role
         self._service_account = service_account
+        self._raw_output_data_config = raw_output_data_config
 
     @property
     def project(self) -> str:
@@ -65,6 +68,9 @@ class RegistrationSettings(object):
     def service_account(self) -> Optional[str]:
         return self._service_account
 
+    @property
+    def raw_output_data_config(self) -> RawOutputDataConfig:
+        return RawOutputDataConfig(self._raw_output_data_config or "")
 
 class CompilationState(object):
     def __init__(self, prefix: str):

--- a/flytekit/annotated/context_manager.py
+++ b/flytekit/annotated/context_manager.py
@@ -15,8 +15,8 @@ from flytekit.common.tasks.sdk_runnable import ExecutionParameters
 from flytekit.configuration import sdk as _sdk_config
 from flytekit.engines.unit import mock_stats as _mock_stats
 from flytekit.interfaces.data import data_proxy as _data_proxy
-from flytekit.models.core import identifier as _identifier
 from flytekit.models.common import RawOutputDataConfig
+from flytekit.models.core import identifier as _identifier
 
 
 class RegistrationSettings(object):
@@ -71,6 +71,7 @@ class RegistrationSettings(object):
     @property
     def raw_output_data_config(self) -> RawOutputDataConfig:
         return RawOutputDataConfig(self._raw_output_data_config or "")
+
 
 class CompilationState(object):
     def __init__(self, prefix: str):

--- a/flytekit/annotated/context_manager.py
+++ b/flytekit/annotated/context_manager.py
@@ -19,12 +19,14 @@ from flytekit.models.core import identifier as _identifier
 
 
 class RegistrationSettings(object):
-    def __init__(self, project: str, domain: str, version: str, image: str, env: Optional[Dict[str, str]]):
+    def __init__(self, project: str, domain: str, version: str, image: str, env: Optional[Dict[str, str]], iam_role: Optional[str] = None, service_account: Optional[str] = None):
         self._project = project
         self._domain = domain
         self._version = version
         self._image = image
         self._env = env or {}
+        self._iam_role = iam_role
+        self._service_account = service_account
 
     @property
     def project(self) -> str:
@@ -45,6 +47,14 @@ class RegistrationSettings(object):
     @property
     def env(self) -> Dict[str, str]:
         return self._env
+
+    @property
+    def iam_role(self)-> Optional[str]:
+        return self._iam_role
+
+    @property
+    def service_account(self)-> Optional[str]:
+        return self._service_account
 
 
 class CompilationState(object):

--- a/flytekit/annotated/interface.py
+++ b/flytekit/annotated/interface.py
@@ -7,9 +7,9 @@ from collections import OrderedDict
 from typing import Any, Dict, Generator, List, Tuple, Type, TypeVar, Union
 
 from flytekit import logger
+from flytekit.annotated import context_manager
 from flytekit.annotated.type_engine import TypeEngine
 from flytekit.models import interface as _interface_models
-from flytekit.annotated import context_manager
 
 
 class Interface(object):
@@ -19,7 +19,6 @@ class Interface(object):
 
     def __init__(
         self, inputs: typing.Dict[str, Union[Type, Tuple[Type, Any]]] = None, outputs: typing.Dict[str, Type] = None,
-
     ):
         """
         :param outputs: Output variables and their types as a dictionary
@@ -93,7 +92,9 @@ class Interface(object):
         return Interface(self._inputs, new_outputs)
 
 
-def transform_inputs_to_parameters(ctx: context_manager.FlyteContext, interface: Interface) -> _interface_models.ParameterMap:
+def transform_inputs_to_parameters(
+    ctx: context_manager.FlyteContext, interface: Interface
+) -> _interface_models.ParameterMap:
     """
     Transforms the given interface (with inputs) to a Parameter Map with defaults set
     :param interface: the interface object

--- a/flytekit/annotated/interface.py
+++ b/flytekit/annotated/interface.py
@@ -47,6 +47,10 @@ class Interface(object):
         return self._inputs
 
     @property
+    def default_inputs_as_kwargs(self) -> Dict[str, Any]:
+        return {k: v[1] for k, v in self._inputs.items() if v[1] is not None}
+
+    @property
     def outputs(self) -> typing.Dict[str, type]:
         return self._outputs
 

--- a/flytekit/annotated/interface.py
+++ b/flytekit/annotated/interface.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import inspect
 import typing
@@ -7,6 +9,7 @@ from typing import Any, Dict, Generator, List, Tuple, Type, TypeVar, Union
 from flytekit import logger
 from flytekit.annotated.type_engine import TypeEngine
 from flytekit.models import interface as _interface_models
+from flytekit.annotated import context_manager
 
 
 class Interface(object):
@@ -16,10 +19,13 @@ class Interface(object):
 
     def __init__(
         self, inputs: typing.Dict[str, Union[Type, Tuple[Type, Any]]] = None, outputs: typing.Dict[str, Type] = None,
+
     ):
         """
         :param outputs: Output variables and their types as a dictionary
-        :param inputs: the variable and its type only
+        :param inputs: Map of input name to either a tuple where the first element is the python type, and the second
+            value is the default, or just a single value which is the python type. The latter case is used by tasks
+            for which perhaps a default value does not make sense. For consistency, we turn it into a tuple.
         """
         self._inputs = {}
         if inputs:
@@ -59,7 +65,7 @@ class Interface(object):
                 del new_inputs[v]
         return Interface(new_inputs, self._outputs)
 
-    def with_inputs(self, extra_inputs: Dict[str, Type]) -> "Interface":
+    def with_inputs(self, extra_inputs: Dict[str, Type]) -> Interface:
         """
         Use this to add additional inputs to the interface. This is useful for adding additional implicit inputs that
         are added without the user requesting for them
@@ -73,7 +79,7 @@ class Interface(object):
             new_inputs[k] = v
         return Interface(new_inputs, self._outputs)
 
-    def with_outputs(self, extra_outputs: Dict[str, Type]) -> "Interface":
+    def with_outputs(self, extra_outputs: Dict[str, Type]) -> Interface:
         """
         This method allows addition of extra outputs are expected from a task specification
         """
@@ -87,7 +93,7 @@ class Interface(object):
         return Interface(self._inputs, new_outputs)
 
 
-def transform_inputs_to_parameters(interface: Interface) -> _interface_models.ParameterMap:
+def transform_inputs_to_parameters(ctx: context_manager.FlyteContext, interface: Interface) -> _interface_models.ParameterMap:
     """
     Transforms the given interface (with inputs) to a Parameter Map with defaults set
     :param interface: the interface object
@@ -99,9 +105,11 @@ def transform_inputs_to_parameters(interface: Interface) -> _interface_models.Pa
     inputs_with_def = interface.inputs_with_defaults
     for k, v in inputs_vars.items():
         val, _default = inputs_with_def[k]
-        # TODO: Fix defaults and required
         required = _default is None
-        params[k] = _interface_models.Parameter(var=v, default=_default, required=required)
+        default_lv = None
+        if _default is not None:
+            default_lv = TypeEngine.to_literal(ctx, _default, python_type=interface.inputs[k], expected=v.type)
+        params[k] = _interface_models.Parameter(var=v, default=default_lv, required=required)
     return _interface_models.ParameterMap(params)
 
 

--- a/flytekit/annotated/launch_plan.py
+++ b/flytekit/annotated/launch_plan.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from flytekit import logger
 from flytekit.annotated import workflow as _annotated_workflow
 from flytekit.annotated.context_manager import FlyteContext, FlyteEntities
 from flytekit.annotated.interface import Interface, transform_inputs_to_parameters

--- a/flytekit/annotated/launch_plan.py
+++ b/flytekit/annotated/launch_plan.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+from typing import Dict, Any
+from flytekit import logger
+from flytekit.annotated import workflow
+from flytekit.annotated.context_manager import FlyteContext
+from flytekit.annotated.interface import (
+    transform_inputs_to_parameters,
+    Interface,
+)
+from flytekit.annotated.type_engine import TypeEngine
+from flytekit.common.launch_plan import SdkLaunchPlan
+from flytekit.models import common as _common_models
+from flytekit.models import interface as _interface_models
+from flytekit.models import launch_plan as _launch_plan_models
+from flytekit.models import literals as _literal_models
+from flytekit.models import schedule as _schedule_model
+
+
+class LaunchPlan(object):
+    # The reason we cache is simply because users may get the default launch plan twice for a single Workflow. We
+    # don't want to create two defaults, could be confusing.
+    CACHE = {}
+
+    @staticmethod
+    def native_kwargs_to_literal_map(ctx: FlyteContext, native_interface: Interface,
+                                     typed_interface: _interface_models.TypedInterface,
+                                     **kwargs) -> _literal_models.LiteralMap:
+        return _literal_models.LiteralMap(
+            literals={
+                k: TypeEngine.to_literal(ctx, v, python_type=native_interface.inputs.get(k),
+                                         expected=typed_interface.inputs.get(k).type)
+                for k, v in kwargs.items()
+            }
+        )
+
+    @staticmethod
+    def get_default_launch_plan(ctx: FlyteContext, workflow: workflow.Workflow) -> LaunchPlan:
+        if workflow.name in LaunchPlan.CACHE:
+            return LaunchPlan.CACHE[workflow.name]
+
+        parameter_map = transform_inputs_to_parameters(ctx, workflow._native_interface)
+
+        lp = LaunchPlan(name=workflow.name, workflow=workflow, parameters=parameter_map,
+                        fixed_inputs=_literal_models.LiteralMap(literals={}))
+
+        LaunchPlan.CACHE[workflow.name] = lp
+        return lp
+
+    # Should we add in things like schedules and annotations and make kwargs an explicit map of inputs?
+    @staticmethod
+    def create(name: str, workflow: workflow.Workflow, **kwargs) -> LaunchPlan:
+        ctx = FlyteContext.current_context()
+        parameters = transform_inputs_to_parameters(ctx, workflow._native_interface)
+        fixed_inputs = LaunchPlan.native_kwargs_to_literal_map(ctx, workflow._native_interface, workflow.interface,
+                                                               **kwargs)
+
+        lp = LaunchPlan(name=name, workflow=workflow, parameters=parameters, fixed_inputs=fixed_inputs)
+        # This is just a convenience - we'll need the fixed inputs LiteralMap for when serializing the Launch Plan out
+        # to protobuf, but for local execution and such, why not save the original Python native values as well so
+        # we don't have to reverse it back every time.
+        lp._saved_inputs = kwargs
+
+        if name in LaunchPlan.CACHE:
+            logger.warning(f"Launch plan named {name} was already created! Make sure your names are unique.")
+        LaunchPlan.CACHE[name] = lp
+        return lp
+
+    # TODO: Add schedule, notifications, labels, annotations, QoS, raw output data config
+    def __init__(self, name: str, workflow: workflow.Workflow, parameters: _interface_models.ParameterMap,
+                 fixed_inputs: _literal_models.LiteralMap,
+                 schedule = None,
+                 notifications = None,
+                 labels = None,
+                 annotations = None,
+                 qos = None,
+                 raw_output_data_config = None):
+        self._name = name
+        self._workflow = workflow
+        # Ensure fixed inputs are not in parameter map
+        parameters = {k: v for k, v in parameters.parameters.items() if k not in fixed_inputs.literals}
+        self._parameters = _interface_models.ParameterMap(parameters=parameters)
+        self._fixed_inputs = fixed_inputs
+        self._saved_inputs = {}
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def parameters(self) -> _interface_models.ParameterMap:
+        return self._parameters
+
+    @property
+    def fixed_inputs(self) -> _literal_models.LiteralMap:
+        return self._fixed_inputs
+
+    @property
+    def workflow(self) -> workflow.Workflow:
+        return self._workflow
+
+    @property
+    def saved_inputs(self) -> Dict[str, Any]:
+        # See note in create()
+        # Since the callsite will typically update the dict returned, and since update updates in place, let's return
+        # a copy.
+        # TODO: What issues will there be when we start introducing custom classes as input types?
+        return self._saved_inputs.copy()
+
+    def __call__(self, *args, **kwargs):
+        if len(args) > 0:
+            raise AssertionError("Only Keyword Arguments are supported for launch plan executions")
+
+        ctx = FlyteContext.current_context()
+        if ctx.compilation_state is not None:
+            # This would literally be a copy paste of the workflow one with the one line change
+            inputs = self.saved_inputs
+            inputs.update(kwargs)
+            results = self.workflow._create_and_link_node(ctx, **inputs)
+            node = ctx.compilation_state.nodes[-1]
+            # Overwrite the flyte entity to be yourself instead.
+            node._flyte_entity = self
+            return results
+        else:
+            # Calling a launch plan should just forward the call to the workflow, nothing more. But let's add in the
+            # saved inputs.
+            inputs = self.saved_inputs
+            inputs.update(kwargs)
+            return self.workflow(*args, **inputs)
+
+    def get_registerable_entity(self) -> SdkLaunchPlan:
+        settings = FlyteContext.current_context().registration_settings
+        if self._registerable_entity is not None:
+            return self._registerable_entity
+
+        if settings.iam_role:
+            auth_role = _common_models.AuthRole(assumable_iam_role=settings.iam_role)
+        elif settings.service_account:
+            auth_role = _common_models.AuthRole(kubernetes_service_account=settings.service_account)
+        else:
+            auth_role = None
+
+        sdk_workflow = self.workflow.get_registerable_entity()
+        self._registerable_entity = SdkLaunchPlan(
+            workflow_id = sdk_workflow.id,
+            entity_metadata=_launch_plan_models.LaunchPlanMetadata(
+                schedule=_schedule_model.Schedule(""), notifications=[],
+            ),
+            default_inputs=self.parameters,
+            fixed_inputs=self.fixed_inputs,
+            labels=_common_models.Labels({}),
+            annotations=_common_models.Annotations({}),
+            auth_role=auth_role,  # TODO: Is None here okay?
+            raw_output_data_config=_common_models.RawOutputDataConfig(""),
+        )
+
+        # Reset just to make sure it's what we give it
+        self._registerable_entity.id._project = settings._project
+        self._registerable_entity.id._domain = settings._domain
+        self._registerable_entity.id._name = self._name
+        self._registerable_entity.id._version = settings._version
+
+        return self._registerable_entity

--- a/flytekit/annotated/launch_plan.py
+++ b/flytekit/annotated/launch_plan.py
@@ -218,6 +218,11 @@ class LaunchPlan(object):
             auth_role=auth_role,  # TODO: Is None here okay?
             raw_output_data_config=self.raw_output_data_config or settings.raw_output_data_config,
         )
+
+        # These two things are normally set to None in the SdkLaunchPlan constructor and filled in by
+        # SdkRunnableLaunchPlan/the registration process, so we need to set them manually. The reason is because these
+        # fields are not part of the underlying LaunchPlanSpec
+        self._registerable_entity._interface = sdk_workflow.interface
         self._registerable_entity._id = _identifier_model.Identifier(
             resource_type=_identifier_model.ResourceType.LAUNCH_PLAN,
             project=settings.project,

--- a/flytekit/annotated/launch_plan.py
+++ b/flytekit/annotated/launch_plan.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 
 from flytekit import logger
 from flytekit.annotated import workflow as _annotated_workflow
-from flytekit.annotated.context_manager import FlyteContext
+from flytekit.annotated.context_manager import FlyteContext, FlyteEntities
 from flytekit.annotated.interface import Interface, transform_inputs_to_parameters
 from flytekit.annotated.type_engine import TypeEngine
 from flytekit.common.launch_plan import SdkLaunchPlan
@@ -72,7 +72,7 @@ class LaunchPlan(object):
             temp_inputs[k] = (workflow._native_interface.inputs[k], v)
         temp_interface = Interface(inputs=temp_inputs, outputs={})
         temp_signature = transform_inputs_to_parameters(ctx, temp_interface)
-        wf_signature_parameters.parameters.update(temp_signature.parameters)
+        wf_signature_parameters._parameters.update(temp_signature.parameters)
 
         # These are fixed inputs that cannot change at launch time. If the same argument is also in default inputs,
         # it'll be taken out from defaults in the LaunchPlan constructor
@@ -118,6 +118,8 @@ class LaunchPlan(object):
 
         # This will eventually hold the registerable launch plan
         self._registerable_entity: Optional[SdkLaunchPlan] = None
+
+        FlyteEntities.entities.append(self)
 
     @property
     def name(self) -> str:

--- a/flytekit/annotated/launch_plan.py
+++ b/flytekit/annotated/launch_plan.py
@@ -51,8 +51,9 @@ class LaunchPlan(object):
         LaunchPlan.CACHE[workflow.name] = lp
         return lp
 
-    @staticmethod
+    @classmethod
     def create(
+        cls,
         name: str,
         workflow: _annotated_workflow.Workflow,
         default_inputs: Dict[str, Any] = None,
@@ -76,11 +77,9 @@ class LaunchPlan(object):
 
         # These are fixed inputs that cannot change at launch time. If the same argument is also in default inputs,
         # it'll be taken out from defaults in the LaunchPlan constructor
-        fixed_lm = LaunchPlan.native_kwargs_to_literal_map(
-            ctx, workflow._native_interface, workflow.interface, **fixed_inputs
-        )
+        fixed_lm = cls.native_kwargs_to_literal_map(ctx, workflow._native_interface, workflow.interface, **fixed_inputs)
 
-        lp = LaunchPlan(name=name, workflow=workflow, parameters=wf_signature_parameters, fixed_inputs=fixed_lm)
+        lp = cls(name=name, workflow=workflow, parameters=wf_signature_parameters, fixed_inputs=fixed_lm)
 
         # This is just a convenience - we'll need the fixed inputs LiteralMap for when serializing the Launch Plan out
         # to protobuf, but for local execution and such, why not save the original Python native values as well so
@@ -88,9 +87,9 @@ class LaunchPlan(object):
         default_inputs.update(fixed_inputs)
         lp._saved_inputs = default_inputs
 
-        if name in LaunchPlan.CACHE:
-            logger.warning(f"Launch plan named {name} was already created! Make sure your names are unique.")
-        LaunchPlan.CACHE[name] = lp
+        if name in cls.CACHE:
+            raise AssertionError(f"Launch plan named {name} was already created! Make sure your names are unique.")
+        cls.CACHE[name] = lp
         return lp
 
     # TODO: Add QoS after it's done

--- a/flytekit/annotated/launch_plan.py
+++ b/flytekit/annotated/launch_plan.py
@@ -93,7 +93,7 @@ class LaunchPlan(object):
         LaunchPlan.CACHE[name] = lp
         return lp
 
-    # TODO: Add schedule, notifications, labels, annotations, QoS, raw output data config
+    # TODO: Add QoS after it's done
     def __init__(
         self,
         name: str,
@@ -114,7 +114,14 @@ class LaunchPlan(object):
         }
         self._parameters = _interface_models.ParameterMap(parameters=parameters)
         self._fixed_inputs = fixed_inputs
+        # See create() for additional information
         self._saved_inputs = {}
+
+        self._schedule = schedule
+        self._notifications = notifications or []
+        self._labels = labels
+        self._annotations = annotations
+        self._raw_output_data_config = raw_output_data_config
 
         # This will eventually hold the registerable launch plan
         self._registerable_entity: Optional[SdkLaunchPlan] = None
@@ -144,6 +151,26 @@ class LaunchPlan(object):
         # a copy.
         # TODO: What issues will there be when we start introducing custom classes as input types?
         return self._saved_inputs.copy()
+
+    @property
+    def schedule(self) -> Optional[_schedule_model.Schedule]:
+        return self._schedule
+
+    @property
+    def notifications(self) -> List[_common_models.Notification]:
+        return self._notifications
+
+    @property
+    def labels(self) -> Optional[_common_models.Labels]:
+        return self._labels
+
+    @property
+    def annotations(self) -> Optional[_common_models.Annotations]:
+        return self._annotations
+
+    @property
+    def raw_output_data_config(self) -> Optional[_common_models.RawOutputDataConfig]:
+        return self._raw_output_data_config
 
     def __call__(self, *args, **kwargs):
         if len(args) > 0:
@@ -186,10 +213,10 @@ class LaunchPlan(object):
             ),
             default_inputs=self.parameters,
             fixed_inputs=self.fixed_inputs,
-            labels=_common_models.Labels({}),
-            annotations=_common_models.Annotations({}),
+            labels=self.labels or _common_models.Labels({}),
+            annotations=self.annotations or _common_models.Annotations({}),
             auth_role=auth_role,  # TODO: Is None here okay?
-            raw_output_data_config=_common_models.RawOutputDataConfig(""),
+            raw_output_data_config=self.raw_output_data_config or _common_models.RawOutputDataConfig(""),
         )
         self._registerable_entity._id = _identifier_model.Identifier(
             resource_type=_identifier_model.ResourceType.LAUNCH_PLAN,

--- a/flytekit/annotated/launch_plan.py
+++ b/flytekit/annotated/launch_plan.py
@@ -209,7 +209,7 @@ class LaunchPlan(object):
         self._registerable_entity = SdkLaunchPlan(
             workflow_id=sdk_workflow.id,
             entity_metadata=_launch_plan_models.LaunchPlanMetadata(
-                schedule=_schedule_model.Schedule(""), notifications=[],
+                schedule=self.schedule, notifications=self.notifications,
             ),
             default_inputs=self.parameters,
             fixed_inputs=self.fixed_inputs,

--- a/flytekit/annotated/launch_plan.py
+++ b/flytekit/annotated/launch_plan.py
@@ -108,7 +108,7 @@ class LaunchPlan(object):
     @property
     def saved_inputs(self) -> Dict[str, Any]:
         # See note in create()
-        # Since the callsite will typically update the dict returned, and since update updates in place, let's return
+        # Since the call-site will typically update the dict returned, and since update updates in place, let's return
         # a copy.
         # TODO: What issues will there be when we start introducing custom classes as input types?
         return self._saved_inputs.copy()

--- a/flytekit/annotated/launch_plan.py
+++ b/flytekit/annotated/launch_plan.py
@@ -216,7 +216,7 @@ class LaunchPlan(object):
             labels=self.labels or _common_models.Labels({}),
             annotations=self.annotations or _common_models.Annotations({}),
             auth_role=auth_role,  # TODO: Is None here okay?
-            raw_output_data_config=self.raw_output_data_config or _common_models.RawOutputDataConfig(""),
+            raw_output_data_config=self.raw_output_data_config or settings.raw_output_data_config,
         )
         self._registerable_entity._id = _identifier_model.Identifier(
             resource_type=_identifier_model.ResourceType.LAUNCH_PLAN,

--- a/flytekit/annotated/node.py
+++ b/flytekit/annotated/node.py
@@ -32,9 +32,9 @@ class Node(object):
         if self._sdk_node is not None:
             return self._sdk_node
         # TODO: Figure out import cycles in the future
+        from flytekit.annotated.launch_plan import LaunchPlan
         from flytekit.annotated.task import PythonTask
         from flytekit.annotated.workflow import Workflow
-        from flytekit.annotated.launch_plan import LaunchPlan
 
         if self._flyte_entity is None:
             raise Exception("Node flyte entity none")

--- a/flytekit/annotated/node.py
+++ b/flytekit/annotated/node.py
@@ -34,6 +34,7 @@ class Node(object):
         # TODO: Figure out import cycles in the future
         from flytekit.annotated.task import PythonTask
         from flytekit.annotated.workflow import Workflow
+        from flytekit.annotated.launch_plan import LaunchPlan
 
         if self._flyte_entity is None:
             raise Exception("Node flyte entity none")
@@ -59,7 +60,14 @@ class Node(object):
                 metadata=self._metadata,
                 sdk_workflow=self._flyte_entity.get_registerable_entity(),
             )
-        # TODO: Add new annotated LaunchPlan when done
+        elif isinstance(self._flyte_entity, LaunchPlan):
+            self._sdk_node = SdkNode(
+                self._id,
+                upstream_nodes=sdk_nodes,
+                bindings=self._bindings,
+                metadata=self._metadata,
+                sdk_launch_plan=self._flyte_entity.get_registerable_entity(),
+            )
         else:
             raise Exception("not a task or workflow, not sure what to do")
 

--- a/flytekit/annotated/task.py
+++ b/flytekit/annotated/task.py
@@ -601,10 +601,6 @@ def task(
         _metadata = metadata(cache, cache_version, retries, interruptible, deprecated, _timeout)
 
         task_instance = TaskTypePlugins[task_type](fn, _metadata, *args, **kwargs)
-        # TODO: One of the things I want to make sure to do is better naming support. At this point, we should already
-        #       be able to determine the name of the task right? Can anyone think of situations where we can't?
-        #       Where does the current instance tracker come into play?
-        task_instance.id = _identifier_model.Identifier(_identifier_model.ResourceType.TASK, "proj", "dom", "blah", "1")
 
         return task_instance
 

--- a/flytekit/annotated/task.py
+++ b/flytekit/annotated/task.py
@@ -29,7 +29,6 @@ from flytekit.models import dynamic_job as _dynamic_job
 from flytekit.models import interface as _interface_models
 from flytekit.models import literals as _literal_models
 from flytekit.models import task as _task_model
-from flytekit.models.core import identifier as _identifier_model
 from flytekit.models.core import workflow as _workflow_model
 
 

--- a/flytekit/annotated/workflow.py
+++ b/flytekit/annotated/workflow.py
@@ -19,7 +19,6 @@ from flytekit.annotated.type_engine import TypeEngine
 from flytekit.common import constants as _common_constants
 from flytekit.common import promise as _common_promise
 from flytekit.common.exceptions import user as _user_exceptions
-from flytekit.common.mixins import registerable as _registerable
 from flytekit.common.workflow import SdkWorkflow as _SdkWorkflow
 from flytekit.models import interface as _interface_models
 from flytekit.models import literals as _literal_models
@@ -258,6 +257,8 @@ class Workflow(object):
 
             raise ValueError("expected outputs and actual outputs do not match")
 
+    # TODO: Let's think about this. I feel like it can be moved somewhere. This function is very close to the task
+    #  version of it, and the launch plan class basically just calls this too.
     def _create_and_link_node(self, ctx: FlyteContext, *args, **kwargs):
         """
         This method is used to create a node representing a subworkflow call in a workflow. It should closely mirror
@@ -308,7 +309,7 @@ class Workflow(object):
 
         return create_task_output(node_outputs)
 
-    def get_registerable_entity(self) -> _registerable.RegisterableEntity:
+    def get_registerable_entity(self) -> _SdkWorkflow:
         settings = FlyteContext.current_context().registration_settings
         if self._registerable_entity is not None:
             return self._registerable_entity

--- a/flytekit/annotated/workflow.py
+++ b/flytekit/annotated/workflow.py
@@ -209,8 +209,9 @@ class Workflow(object):
 
         # Handle subworkflows in compilation
         if ctx.compilation_state is not None:
-            return self._create_and_link_node(ctx, **kwargs)
-
+            input_kwargs = self._native_interface.default_inputs_as_kwargs
+            input_kwargs.update(kwargs)
+            return self._create_and_link_node(ctx, **input_kwargs)
         elif (
             ctx.execution_state is not None and ctx.execution_state.mode == ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION
         ):

--- a/flytekit/annotated/workflow.py
+++ b/flytekit/annotated/workflow.py
@@ -126,10 +126,9 @@ class Workflow(object):
         Supply static Python native values in the kwargs if you want them to be used in the compilation. This mimics
         a 'closure' in the traditional sense of the word.
         """
-        # TODO: should we even define it here?
-        self._input_parameters = transform_inputs_to_parameters(self._native_interface)
-        all_nodes = []
         ctx = FlyteContext.current_context()
+        self._input_parameters = transform_inputs_to_parameters(ctx, self._native_interface)
+        all_nodes = []
         prefix = f"{ctx.compilation_state.prefix}-{self.short_name}-" if ctx.compilation_state is not None else None
         with ctx.new_compilation_context(prefix=prefix) as comp_ctx:
             # Construct the default input promise bindings, but then override with the provided inputs, if any
@@ -343,14 +342,8 @@ def workflow(_workflow_function=None):
     # workflows need to have the body of the function itself run at module-load time. This is because the body of the
     # workflow is what expresses the workflow structure.
     def wrapper(fn):
-        # TODO: Again, at this point, we should be able to identify the name of the workflow
-        workflow_id = _identifier_model.Identifier(
-            _identifier_model.ResourceType.WORKFLOW, "proj", "dom", "moreblah", "1"
-        )
         workflow_instance = Workflow(fn)
         workflow_instance.compile()
-        workflow_instance.id = workflow_id
-
         return workflow_instance
 
     if _workflow_function:

--- a/flytekit/annotated/workflow.py
+++ b/flytekit/annotated/workflow.py
@@ -329,10 +329,10 @@ class Workflow(object):
             output_bindings=self._output_bindings,
         )
         # Reset just to make sure it's what we give it
-        self._registerable_entity.id._project = settings._project
-        self._registerable_entity.id._domain = settings._domain
+        self._registerable_entity.id._project = settings.project
+        self._registerable_entity.id._domain = settings.domain
         self._registerable_entity.id._name = self._name
-        self._registerable_entity.id._version = settings._version
+        self._registerable_entity.id._version = settings.version
 
         return self._registerable_entity
 

--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -97,6 +97,7 @@ def serialize_all(project, domain, pkgs, version, folder=None):
         env=env,
         iam_role=_auth_config.ASSUMABLE_IAM_ROLE.get(),
         service_account=_auth_config.KUBERNETES_SERVICE_ACCOUNT.get(),
+        raw_output_data_config=_auth_config.RAW_OUTPUT_DATA_PREFIX.get()
     )
     with flyte_context.FlyteContext.current_context().new_registration_settings(
         registration_settings=registration_settings

--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -97,7 +97,7 @@ def serialize_all(project, domain, pkgs, version, folder=None):
         env=env,
         iam_role=_auth_config.ASSUMABLE_IAM_ROLE.get(),
         service_account=_auth_config.KUBERNETES_SERVICE_ACCOUNT.get(),
-        raw_output_data_config=_auth_config.RAW_OUTPUT_DATA_PREFIX.get()
+        raw_output_data_config=_auth_config.RAW_OUTPUT_DATA_PREFIX.get(),
     )
     with flyte_context.FlyteContext.current_context().new_registration_settings(
         registration_settings=registration_settings

--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -110,7 +110,9 @@ def serialize_all(project, domain, pkgs, version, folder=None):
 
         click.echo(f"Found {len(flyte_context.FlyteEntities.entities)} tasks/workflows")
 
-        for entity in flyte_context.FlyteEntities.entities:
+        # TODO: Clean up the copy() - it's here because we call get_default_launch_plan, which may create a LaunchPlan
+        #  object, which gets added to the FlyteEntities.entities list, which we're iterating over.
+        for entity in flyte_context.FlyteEntities.entities.copy():
             # TODO: Add a reachable check. Since these entities are always added by the constructor, weird things can
             #  happen. If someone creates a workflow inside a workflow, we don't actually want the inner workflow to be
             #  registered. Or do we? Certainly, we don't want inner tasks to be registered because we don't know how
@@ -118,7 +120,7 @@ def serialize_all(project, domain, pkgs, version, folder=None):
             #  Also a user may import dir_b.workflows from dir_a.workflows but workflow packages might only
             #  specify dir_a
 
-            if isinstance(entity, PythonTask) or isinstance(entity, Workflow):
+            if isinstance(entity, PythonTask) or isinstance(entity, Workflow) or isinstance(entity, LaunchPlan):
                 serializable = entity.get_registerable_entity()
                 loaded_entities.append(serializable)
 

--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -5,9 +5,9 @@ import os as _os
 import click
 
 from flytekit.annotated import context_manager as flyte_context
+from flytekit.annotated.launch_plan import LaunchPlan
 from flytekit.annotated.task import PythonTask
 from flytekit.annotated.workflow import Workflow
-from flytekit.annotated.launch_plan import LaunchPlan
 from flytekit.clis.sdk_in_container.constants import CTX_DOMAIN, CTX_PACKAGES, CTX_PROJECT, CTX_VERSION
 from flytekit.common import utils as _utils
 from flytekit.common.core import identifier as _identifier
@@ -15,8 +15,8 @@ from flytekit.common.exceptions.scopes import system_entry_point
 from flytekit.common.tasks import task as _sdk_task
 from flytekit.common.utils import write_proto_to_file as _write_proto_to_file
 from flytekit.configuration import TemporaryConfiguration
-from flytekit.configuration import internal as _internal_config, auth as _auth_config
-from flytekit.models.core import identifier as _identifier_models
+from flytekit.configuration import auth as _auth_config
+from flytekit.configuration import internal as _internal_config
 from flytekit.tools.module_loader import iterate_registerable_entities_in_order
 
 
@@ -90,8 +90,13 @@ def serialize_all(project, domain, pkgs, version, folder=None):
     }
 
     registration_settings = flyte_context.RegistrationSettings(
-        project=project, domain=domain, version=version, image=_internal_config.IMAGE.get(), env=env,
-        iam_role=_auth_config.ASSUMABLE_IAM_ROLE.get(), service_account=_auth_config.KUBERNETES_SERVICE_ACCOUNT.get(),
+        project=project,
+        domain=domain,
+        version=version,
+        image=_internal_config.IMAGE.get(),
+        env=env,
+        iam_role=_auth_config.ASSUMABLE_IAM_ROLE.get(),
+        service_account=_auth_config.KUBERNETES_SERVICE_ACCOUNT.get(),
     )
     with flyte_context.FlyteContext.current_context().new_registration_settings(
         registration_settings=registration_settings
@@ -187,9 +192,7 @@ def tasks(ctx, version=None, folder=None):
         click.echo(f"Writing output to {folder}")
 
     version = (
-        version
-        or ctx.obj[CTX_VERSION]
-        or _internal_config.look_up_version_from_image_tag(_internal_config.IMAGE.get())
+        version or ctx.obj[CTX_VERSION] or _internal_config.look_up_version_from_image_tag(_internal_config.IMAGE.get())
     )
 
     internal_settings = {
@@ -232,9 +235,7 @@ def workflows(ctx, version=None, folder=None):
     pkgs = ctx.obj[CTX_PACKAGES]
 
     version = (
-        version
-        or ctx.obj[CTX_VERSION]
-        or _internal_config.look_up_version_from_image_tag(_internal_config.IMAGE.get())
+        version or ctx.obj[CTX_VERSION] or _internal_config.look_up_version_from_image_tag(_internal_config.IMAGE.get())
     )
 
     internal_settings = {

--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -166,7 +166,7 @@ def serialize(ctx):
         object contains the WorkflowTemplate, along with the relevant tasks for that workflow.  In lieu of Admin,
         this serialization step will set the URN of the tasks to the fully qualified name of the task function.
     """
-    click.echo("Serializing Flyte elements with image {}".format(_internal_configuration.IMAGE.get()))
+    click.echo("Serializing Flyte elements with image {}".format(_internal_config.IMAGE.get()))
 
 
 @click.command("tasks")
@@ -189,7 +189,7 @@ def tasks(ctx, version=None, folder=None):
     version = (
         version
         or ctx.obj[CTX_VERSION]
-        or _internal_configuration.look_up_version_from_image_tag(_internal_configuration.IMAGE.get())
+        or _internal_config.look_up_version_from_image_tag(_internal_config.IMAGE.get())
     )
 
     internal_settings = {
@@ -199,7 +199,7 @@ def tasks(ctx, version=None, folder=None):
     }
     # Populate internal settings for project/domain/version from the environment so that the file names are resolved
     # with the correct strings. The file itself doesn't need to change though.
-    with TemporaryConfiguration(_internal_configuration.CONFIGURATION_PATH.get(), internal_settings):
+    with TemporaryConfiguration(_internal_config.CONFIGURATION_PATH.get(), internal_settings):
         _logging.debug(
             "Serializing with settings\n"
             "\n  Project: {}"
@@ -234,7 +234,7 @@ def workflows(ctx, version=None, folder=None):
     version = (
         version
         or ctx.obj[CTX_VERSION]
-        or _internal_configuration.look_up_version_from_image_tag(_internal_configuration.IMAGE.get())
+        or _internal_config.look_up_version_from_image_tag(_internal_config.IMAGE.get())
     )
 
     internal_settings = {
@@ -244,7 +244,7 @@ def workflows(ctx, version=None, folder=None):
     }
     # Populate internal settings for project/domain/version from the environment so that the file names are resolved
     # with the correct strings. The file itself doesn't need to change though.
-    with TemporaryConfiguration(_internal_configuration.CONFIGURATION_PATH.get(), internal_settings):
+    with TemporaryConfiguration(_internal_config.CONFIGURATION_PATH.get(), internal_settings):
         _logging.debug(
             "Serializing with settings\n"
             "\n  Project: {}"

--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -14,8 +14,7 @@ from flytekit.common.exceptions.scopes import system_entry_point
 from flytekit.common.tasks import task as _sdk_task
 from flytekit.common.utils import write_proto_to_file as _write_proto_to_file
 from flytekit.configuration import TemporaryConfiguration
-from flytekit.configuration import internal as _internal_config
-from flytekit.configuration import internal as _internal_configuration
+from flytekit.configuration import internal as _internal_config, auth as _auth_config
 from flytekit.models.core import identifier as _identifier_models
 from flytekit.tools.module_loader import iterate_registerable_entities_in_order
 
@@ -90,7 +89,8 @@ def serialize_all(project, domain, pkgs, version, folder=None):
     }
 
     registration_settings = flyte_context.RegistrationSettings(
-        project=project, domain=domain, version=version, image=_internal_configuration.IMAGE.get(), env=env
+        project=project, domain=domain, version=version, image=_internal_config.IMAGE.get(), env=env,
+        iam_role=_auth_config.ASSUMABLE_IAM_ROLE.get(), service_account=_auth_config.KUBERNETES_SERVICE_ACCOUNT.get(),
     )
     with flyte_context.FlyteContext.current_context().new_registration_settings(
         registration_settings=registration_settings

--- a/flytekit/models/interface.py
+++ b/flytekit/models/interface.py
@@ -180,7 +180,7 @@ class Parameter(_common.FlyteIdlEntity):
         return _interface_pb2.Parameter(
             var=self.var.to_flyte_idl(),
             default=self.default.to_flyte_idl() if self.default is not None else None,
-            required=self.required,
+            required=self.required if self.default is None else None,
         )
 
     @classmethod

--- a/tests/flytekit/unit/annotated/test_interface.py
+++ b/tests/flytekit/unit/annotated/test_interface.py
@@ -4,9 +4,14 @@ import typing
 from typing import Dict, List
 
 from flytekit import typing as flytekit_typing
-from flytekit.annotated.interface import extract_return_annotation, transform_variable_map, transform_inputs_to_parameters, transform_signature_to_interface
-from flytekit.models.core import types as _core_types
 from flytekit.annotated import context_manager
+from flytekit.annotated.interface import (
+    extract_return_annotation,
+    transform_inputs_to_parameters,
+    transform_signature_to_interface,
+    transform_variable_map,
+)
+from flytekit.models.core import types as _core_types
 
 
 def test_extract_only():
@@ -140,8 +145,10 @@ def test_file_types():
 
 def test_parameters_and_defaults():
     ctx = context_manager.FlyteContext.current_context()
+
     def z(a: int, b: str) -> typing.Tuple[int, str]:
         ...
+
     our_interface = transform_signature_to_interface(inspect.signature(z))
     params = transform_inputs_to_parameters(ctx, our_interface)
     assert params.parameters["a"].required
@@ -151,6 +158,7 @@ def test_parameters_and_defaults():
 
     def z(a: int, b: str = "hello") -> typing.Tuple[int, str]:
         ...
+
     our_interface = transform_signature_to_interface(inspect.signature(z))
     params = transform_inputs_to_parameters(ctx, our_interface)
     assert params.parameters["a"].required
@@ -158,8 +166,9 @@ def test_parameters_and_defaults():
     assert not params.parameters["b"].required
     assert params.parameters["b"].default.scalar.primitive.string_value == "hello"
 
-    def z(a: int=7, b: str="eleven") -> typing.Tuple[int, str]:
+    def z(a: int = 7, b: str = "eleven") -> typing.Tuple[int, str]:
         ...
+
     our_interface = transform_signature_to_interface(inspect.signature(z))
     params = transform_inputs_to_parameters(ctx, our_interface)
     assert not params.parameters["a"].required

--- a/tests/flytekit/unit/annotated/test_interface.py
+++ b/tests/flytekit/unit/annotated/test_interface.py
@@ -4,8 +4,9 @@ import typing
 from typing import Dict, List
 
 from flytekit import typing as flytekit_typing
-from flytekit.annotated.interface import extract_return_annotation, transform_variable_map
+from flytekit.annotated.interface import extract_return_annotation, transform_variable_map, transform_inputs_to_parameters, transform_signature_to_interface
 from flytekit.models.core import types as _core_types
+from flytekit.annotated import context_manager
 
 
 def test_extract_only():
@@ -135,3 +136,33 @@ def test_file_types():
 
     return_type = extract_return_annotation(inspect.signature(t1).return_annotation)
     assert return_type["out_0"].extension() == flytekit_typing.FlyteFilePath["svg"].extension()
+
+
+def test_parameters_and_defaults():
+    ctx = context_manager.FlyteContext.current_context()
+    def z(a: int, b: str) -> typing.Tuple[int, str]:
+        ...
+    our_interface = transform_signature_to_interface(inspect.signature(z))
+    params = transform_inputs_to_parameters(ctx, our_interface)
+    assert params.parameters["a"].required
+    assert params.parameters["a"].default is None
+    assert params.parameters["b"].required
+    assert params.parameters["b"].default is None
+
+    def z(a: int, b: str = "hello") -> typing.Tuple[int, str]:
+        ...
+    our_interface = transform_signature_to_interface(inspect.signature(z))
+    params = transform_inputs_to_parameters(ctx, our_interface)
+    assert params.parameters["a"].required
+    assert params.parameters["a"].default is None
+    assert not params.parameters["b"].required
+    assert params.parameters["b"].default.scalar.primitive.string_value == "hello"
+
+    def z(a: int=7, b: str="eleven") -> typing.Tuple[int, str]:
+        ...
+    our_interface = transform_signature_to_interface(inspect.signature(z))
+    params = transform_inputs_to_parameters(ctx, our_interface)
+    assert not params.parameters["a"].required
+    assert params.parameters["a"].default.scalar.primitive.integer == 7
+    assert not params.parameters["b"].required
+    assert params.parameters["b"].default.scalar.primitive.string_value == "eleven"

--- a/tests/flytekit/unit/annotated/test_type_hints.py
+++ b/tests/flytekit/unit/annotated/test_type_hints.py
@@ -584,7 +584,7 @@ def test_wf1_df():
     assert result_df.all().all()
 
 
-def test_wf1_with_subwffdsa():
+def test_wf1_with_lp_node():
     @task
     def t1(a: int) -> typing.NamedTuple("OutputsBC", t1_int_output=int, c=str):
         a = a + 2
@@ -631,7 +631,7 @@ def test_wf1_with_subwffdsa():
     assert my_wf2() == (44, 'world-44', 'world-5', 'world-7')
 
 
-def test_wf1_with_subwffdsafdsa():
+def test_lp_serialize():
     @task
     def t1(a: int) -> typing.NamedTuple("OutputsBC", t1_int_output=int, c=str):
         a = a + 2

--- a/tests/flytekit/unit/annotated/test_type_hints.py
+++ b/tests/flytekit/unit/annotated/test_type_hints.py
@@ -8,7 +8,7 @@ import pytest
 import flytekit.annotated.task
 import flytekit.annotated.workflow
 from flytekit import typing as flytekit_typing
-from flytekit.annotated import context_manager, promise
+from flytekit.annotated import context_manager, launch_plan, promise
 from flytekit.annotated.condition import conditional
 from flytekit.annotated.context_manager import ExecutionState
 from flytekit.annotated.promise import Promise
@@ -20,7 +20,7 @@ from flytekit.common.promise import NodeOutput
 from flytekit.interfaces.data.data_proxy import FileAccessProvider
 from flytekit.models.core import types as _core_types
 from flytekit.models.types import LiteralType, SimpleType
-from flytekit.annotated import launch_plan
+
 
 def test_default_wf_params_works():
     @task
@@ -600,11 +600,11 @@ def test_lp_default_handling():
     assert len(lp.parameters.parameters) == 0
     assert len(lp.fixed_inputs.literals) == 0
 
-    lp_with_defaults = launch_plan.LaunchPlan.create("test2", my_wf, default_inputs={'a': 3})
+    lp_with_defaults = launch_plan.LaunchPlan.create("test2", my_wf, default_inputs={"a": 3})
     assert len(lp_with_defaults.parameters.parameters) == 1
     assert len(lp_with_defaults.fixed_inputs.literals) == 0
 
-    lp_with_fixed = launch_plan.LaunchPlan.create("test3", my_wf, fixed_inputs={'a': 3})
+    lp_with_fixed = launch_plan.LaunchPlan.create("test3", my_wf, fixed_inputs={"a": 3})
     assert len(lp_with_fixed.parameters.parameters) == 0
     assert len(lp_with_fixed.fixed_inputs.literals) == 1
 
@@ -618,19 +618,19 @@ def test_lp_default_handling():
     assert len(lp.parameters.parameters) == 1
     assert len(lp.fixed_inputs.literals) == 0
 
-    lp_with_defaults = launch_plan.LaunchPlan.create("test5", my_wf2, default_inputs={'a': 3})
+    lp_with_defaults = launch_plan.LaunchPlan.create("test5", my_wf2, default_inputs={"a": 3})
     assert len(lp_with_defaults.parameters.parameters) == 2
     assert len(lp_with_defaults.fixed_inputs.literals) == 0
     # Launch plan defaults override wf defaults
-    assert lp_with_defaults(b=3) == ('world-5', 'world-5', 5, 5)
+    assert lp_with_defaults(b=3) == ("world-5", "world-5", 5, 5)
 
-    lp_with_fixed = launch_plan.LaunchPlan.create("test6", my_wf2, fixed_inputs={'a': 3})
+    lp_with_fixed = launch_plan.LaunchPlan.create("test6", my_wf2, fixed_inputs={"a": 3})
     assert len(lp_with_fixed.parameters.parameters) == 1
     assert len(lp_with_fixed.fixed_inputs.literals) == 1
     # Launch plan defaults override wf defaults
-    assert lp_with_fixed(b=3) == ('world-5', 'world-5', 5, 5)
+    assert lp_with_fixed(b=3) == ("world-5", "world-5", 5, 5)
 
-    lp_with_fixed = launch_plan.LaunchPlan.create("test7", my_wf2, fixed_inputs={'b': 3})
+    lp_with_fixed = launch_plan.LaunchPlan.create("test7", my_wf2, fixed_inputs={"b": 3})
     assert len(lp_with_fixed.parameters.parameters) == 0
     assert len(lp_with_fixed.fixed_inputs.literals) == 1
 
@@ -648,7 +648,7 @@ def test_wf1_with_lp_node():
         return y, v
 
     lp = launch_plan.LaunchPlan.create("test1", my_subwf)
-    lp_with_defaults = launch_plan.LaunchPlan.create("test2", my_subwf, default_inputs={'a': 3})
+    lp_with_defaults = launch_plan.LaunchPlan.create("test2", my_subwf, default_inputs={"a": 3})
 
     @workflow
     def my_wf(a: int = 42) -> (int, str, str):
@@ -667,7 +667,7 @@ def test_wf1_with_lp_node():
         u, v = lp_with_defaults()
         return x, y, u, v
 
-    assert my_wf2() == (44, 'world-44', 'world-5', 'world-7')
+    assert my_wf2() == (44, "world-44", "world-5", "world-7")
 
     @workflow
     def my_wf3(a: int = 42) -> (int, str, str, str):
@@ -675,7 +675,7 @@ def test_wf1_with_lp_node():
         u, v = lp_with_defaults(a=x)
         return x, y, u, v
 
-    assert my_wf2() == (44, 'world-44', 'world-5', 'world-7')
+    assert my_wf2() == (44, "world-44", "world-5", "world-7")
 
 
 def test_lp_serialize():
@@ -695,11 +695,16 @@ def test_lp_serialize():
         return y, v
 
     lp = launch_plan.LaunchPlan.create("test1", my_subwf)
-    lp_with_defaults = launch_plan.LaunchPlan.create("test2", my_subwf, default_inputs={'a': 3})
+    lp_with_defaults = launch_plan.LaunchPlan.create("test2", my_subwf, default_inputs={"a": 3})
 
     registration_settings = context_manager.RegistrationSettings(
-        project="proj", domain="dom", version="123", image="asdf/fdsa:123", env={},
-        iam_role="test:iam:role", service_account=None,
+        project="proj",
+        domain="dom",
+        version="123",
+        image="asdf/fdsa:123",
+        env={},
+        iam_role="test:iam:role",
+        service_account=None,
     )
     with context_manager.FlyteContext.current_context().new_registration_settings(
         registration_settings=registration_settings

--- a/tests/flytekit/unit/annotated/test_type_hints.py
+++ b/tests/flytekit/unit/annotated/test_type_hints.py
@@ -648,8 +648,8 @@ def test_wf1_with_lp_node():
         u, v = t1(a=x)
         return y, v
 
-    lp = launch_plan.LaunchPlan.create("test1", my_subwf)
-    lp_with_defaults = launch_plan.LaunchPlan.create("test2", my_subwf, default_inputs={"a": 3})
+    lp = launch_plan.LaunchPlan.create("lp_nodetest1", my_subwf)
+    lp_with_defaults = launch_plan.LaunchPlan.create("lp_nodetest2", my_subwf, default_inputs={"a": 3})
 
     @workflow
     def my_wf(a: int = 42) -> (int, str, str):
@@ -695,8 +695,8 @@ def test_lp_serialize():
         u, v = t1(a=x)
         return y, v
 
-    lp = launch_plan.LaunchPlan.create("test1", my_subwf)
-    lp_with_defaults = launch_plan.LaunchPlan.create("test2", my_subwf, default_inputs={"a": 3})
+    lp = launch_plan.LaunchPlan.create("serialize_test1", my_subwf)
+    lp_with_defaults = launch_plan.LaunchPlan.create("serialize_test2", my_subwf, default_inputs={"a": 3})
 
     registration_settings = context_manager.RegistrationSettings(
         project="proj",

--- a/tests/flytekit/unit/annotated/test_type_hints.py
+++ b/tests/flytekit/unit/annotated/test_type_hints.py
@@ -20,6 +20,7 @@ from flytekit.common.nodes import SdkNode
 from flytekit.common.promise import NodeOutput
 from flytekit.interfaces.data.data_proxy import FileAccessProvider
 from flytekit.models.core import types as _core_types
+from flytekit.models.interface import Parameter
 from flytekit.models.types import LiteralType, SimpleType
 
 
@@ -716,6 +717,12 @@ def test_lp_serialize():
         sdk_lp = lp_with_defaults.get_registerable_entity()
         assert len(sdk_lp.default_inputs.parameters) == 1
         assert len(sdk_lp.fixed_inputs.literals) == 0
+
+        # Adding a check to make sure oneof is respected. Tricky with booleans... if a default is specified, the
+        # required field needs to be None, not False.
+        parameter_a = sdk_lp.default_inputs.parameters["a"]
+        parameter_a = Parameter.from_flyte_idl(parameter_a.to_flyte_idl())
+        assert parameter_a.default is not None
 
 
 def test_wf_container_task():


### PR DESCRIPTION
ignore unless ketan/haytham.

* Adds a new Launch Plan class in the same pattern as the new Task and Workflow classes
* Remove the identifier_model.Identifier instantiations in Task and Workflow now that we handle it at serialization time.
* Call the type engine to create literals when making the ParameterMap in interface.
* Stupid oneof in Parameter tripped me up for hours. Thanks Haytham.
