### PR TITLE
Fix to use natural sort for flytekit Sagemaker script

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,7 +12,6 @@ coverage==5.3             # via -r dev-requirements.in
 flake8-black==0.2.1       # via -r dev-requirements.in
 flake8-isort==4.0.0       # via -r dev-requirements.in
 flake8==3.8.4             # via -r dev-requirements.in, flake8-black, flake8-isort
-importlib-metadata==2.0.0  # via -c requirements.txt, flake8, pluggy, pytest
 iniconfig==1.1.1          # via pytest
 isort==5.6.4              # via -r dev-requirements.in, flake8-isort
 mccabe==0.6.1             # via flake8
@@ -28,6 +27,5 @@ pytest==6.1.2             # via -r dev-requirements.in
 regex==2020.10.28         # via -c requirements.txt, black
 six==1.15.0               # via -c requirements.txt, packaging
 testfixtures==6.15.0      # via flake8-isort
-toml==0.10.1              # via -c requirements.txt, black, pytest
+toml==0.10.2              # via -c requirements.txt, black, pytest
 typed-ast==1.4.1          # via -c requirements.txt, black
-zipp==3.4.0               # via -c requirements.txt, importlib-metadata

--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,7 +2,7 @@ import logging as _logging
 
 import flytekit.plugins  # noqa: F401
 
-__version__ = "0.14.2"
+__version__ = "0.14.3"
 
 logger = _logging.getLogger("flytekit")
 

--- a/requirements-spark3.txt
+++ b/requirements-spark3.txt
@@ -13,13 +13,13 @@ attrs==20.2.0             # via black, jsonschema
 backcall==0.2.0           # via ipython
 bcrypt==3.2.0             # via paramiko
 black==19.10b0            # via flytekit, papermill
-boto3==1.16.8             # via flytekit, sagemaker-training
-botocore==1.19.8          # via boto3, s3transfer
+boto3==1.16.11            # via flytekit, sagemaker-training
+botocore==1.19.11         # via boto3, s3transfer
 certifi==2020.6.20        # via requests
 cffi==1.14.3              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
 click==7.1.2              # via black, flytekit, hmsclient, papermill
-croniter==0.3.35          # via flytekit
+croniter==0.3.36          # via flytekit
 cryptography==3.2.1       # via paramiko
 decorator==4.4.2          # via ipython, retry
 deprecated==1.2.10        # via flytekit
@@ -30,11 +30,10 @@ greenlet==0.4.17          # via gevent
 grpcio==1.33.2            # via flytekit
 hmsclient==0.1.1          # via flytekit
 idna==2.10                # via requests
-importlib-metadata==2.0.0  # via jsonschema, keyring
 inotify_simple==1.2.1     # via sagemaker-training
 ipykernel==5.3.4          # via flytekit
 ipython-genutils==0.2.0   # via nbformat, traitlets
-ipython==7.18.1           # via ipykernel
+ipython==7.19.0           # via ipykernel
 jedi==0.17.2              # via ipython
 jmespath==0.10.0          # via boto3, botocore
 jsonschema==3.2.0         # via nbformat
@@ -42,13 +41,13 @@ jupyter-client==6.1.7     # via ipykernel, nbclient
 jupyter-core==4.6.3       # via jupyter-client, nbformat
 k8s-proto==0.0.3          # via flytekit
 keyring==21.4.0           # via flytekit
-natsort==7.0.1            # via croniter
+natsort==7.0.1            # via croniter, flytekit
 nbclient==0.5.1           # via papermill
 nbformat==5.0.8           # via nbclient, papermill
 nest-asyncio==1.4.2       # via nbclient
-numpy==1.19.3             # via flytekit, pandas, pyarrow, sagemaker-training, scipy
-pandas==1.1.3             # via flytekit
-papermill==2.2.0          # via flytekit
+numpy==1.19.4             # via flytekit, pandas, pyarrow, sagemaker-training, scipy
+pandas==1.1.4             # via flytekit
+papermill==2.2.2          # via flytekit
 paramiko==2.7.2           # via sagemaker-training
 parso==0.7.1              # via jedi
 pathspec==0.8.0           # via black
@@ -85,8 +84,8 @@ statsd==3.3.0             # via flytekit
 tenacity==6.2.0           # via papermill
 textwrap3==0.9.2          # via ansiwrap
 thrift==0.13.0            # via hmsclient
-toml==0.10.1              # via black
-tornado==6.0.4            # via ipykernel, jupyter-client
+toml==0.10.2              # via black
+tornado==6.1              # via ipykernel, jupyter-client
 tqdm==4.51.0              # via papermill
 traitlets==5.0.5          # via ipykernel, ipython, jupyter-client, jupyter-core, nbclient, nbformat
 typed-ast==1.4.1          # via black
@@ -94,7 +93,6 @@ urllib3==1.25.11          # via botocore, flytekit, requests, responses
 wcwidth==0.2.5            # via prompt-toolkit
 werkzeug==1.0.1           # via sagemaker-training
 wrapt==1.12.1             # via deprecated, flytekit
-zipp==3.4.0               # via importlib-metadata
 zope.event==4.5.0         # via gevent
 zope.interface==5.1.2     # via gevent
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,13 +13,13 @@ attrs==20.2.0             # via black, jsonschema
 backcall==0.2.0           # via ipython
 bcrypt==3.2.0             # via paramiko
 black==19.10b0            # via flytekit, papermill
-boto3==1.16.8             # via flytekit, sagemaker-training
-botocore==1.19.8          # via boto3, s3transfer
+boto3==1.16.11            # via flytekit, sagemaker-training
+botocore==1.19.11         # via boto3, s3transfer
 certifi==2020.6.20        # via requests
 cffi==1.14.3              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
 click==7.1.2              # via black, flytekit, hmsclient, papermill
-croniter==0.3.35          # via flytekit
+croniter==0.3.36          # via flytekit
 cryptography==3.2.1       # via paramiko
 decorator==4.4.2          # via ipython, retry
 deprecated==1.2.10        # via flytekit
@@ -30,11 +30,10 @@ greenlet==0.4.17          # via gevent
 grpcio==1.33.2            # via flytekit
 hmsclient==0.1.1          # via flytekit
 idna==2.10                # via requests
-importlib-metadata==2.0.0  # via jsonschema, keyring
 inotify_simple==1.2.1     # via sagemaker-training
 ipykernel==5.3.4          # via flytekit
 ipython-genutils==0.2.0   # via nbformat, traitlets
-ipython==7.18.1           # via ipykernel
+ipython==7.19.0           # via ipykernel
 jedi==0.17.2              # via ipython
 jmespath==0.10.0          # via boto3, botocore
 jsonschema==3.2.0         # via nbformat
@@ -42,13 +41,13 @@ jupyter-client==6.1.7     # via ipykernel, nbclient
 jupyter-core==4.6.3       # via jupyter-client, nbformat
 k8s-proto==0.0.3          # via flytekit
 keyring==21.4.0           # via flytekit
-natsort==7.0.1            # via croniter
+natsort==7.0.1            # via croniter, flytekit
 nbclient==0.5.1           # via papermill
 nbformat==5.0.8           # via nbclient, papermill
 nest-asyncio==1.4.2       # via nbclient
-numpy==1.19.3             # via flytekit, pandas, pyarrow, sagemaker-training, scipy
-pandas==1.1.3             # via flytekit
-papermill==2.2.0          # via flytekit
+numpy==1.19.4             # via flytekit, pandas, pyarrow, sagemaker-training, scipy
+pandas==1.1.4             # via flytekit
+papermill==2.2.2          # via flytekit
 paramiko==2.7.2           # via sagemaker-training
 parso==0.7.1              # via jedi
 pathspec==0.8.0           # via black
@@ -85,8 +84,8 @@ statsd==3.3.0             # via flytekit
 tenacity==6.2.0           # via papermill
 textwrap3==0.9.2          # via ansiwrap
 thrift==0.13.0            # via hmsclient
-toml==0.10.1              # via black
-tornado==6.0.4            # via ipykernel, jupyter-client
+toml==0.10.2              # via black
+tornado==6.1              # via ipykernel, jupyter-client
 tqdm==4.51.0              # via papermill
 traitlets==5.0.5          # via ipykernel, ipython, jupyter-client, jupyter-core, nbclient, nbformat
 typed-ast==1.4.1          # via black
@@ -94,7 +93,6 @@ urllib3==1.25.11          # via botocore, flytekit, requests, responses
 wcwidth==0.2.5            # via prompt-toolkit
 werkzeug==1.0.1           # via sagemaker-training
 wrapt==1.12.1             # via deprecated, flytekit
-zipp==3.4.0               # via importlib-metadata
 zope.event==4.5.0         # via gevent
 zope.interface==5.1.2     # via gevent
 

--- a/scripts/flytekit_sagemaker_runner.py
+++ b/scripts/flytekit_sagemaker_runner.py
@@ -4,6 +4,8 @@ import os
 import subprocess
 import sys
 
+from natsort import natsorted
+
 FLYTE_ARG_PREFIX = "--__FLYTE"
 FLYTE_ENV_VAR_PREFIX = f"{FLYTE_ARG_PREFIX}_ENV_VAR_"
 FLYTE_CMD_PREFIX = f"{FLYTE_ARG_PREFIX}_CMD_"
@@ -65,7 +67,7 @@ def parse_args(cli_args):
 
 def sort_flyte_cmd(flyte_cmd):
     # Order the cmd using the index (the first element in each tuple)
-    flyte_cmd.sort(key=lambda x: x[0])
+    flyte_cmd = natsorted(flyte_cmd, key=lambda x: x[0])
     flyte_cmd = [x[1] for x in flyte_cmd]
     return flyte_cmd
 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "ipykernel>=5.0.0",
         "black==19.10b0",
         "retry==0.9.2",
+        "natsort>=7.0.1",
     ],
     extras_require=extras_require,
     scripts=[


### PR DESCRIPTION
# TL;DR
My test SageMaker jobs were failing, but Chang-Hong's jobs worked. After investigating, we discovered that the issue is a text sort that should be a "natural" order sort.

Details for the issue in https://lyft.slack.com/archives/CUMH80X6W/p1604517799068200 and an explanation of this fix in https://lyft.slack.com/archives/CUMH80X6W/p1604526254078800.

JIRA link: https://jira.lyft.net/browse/AVSW-64440

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Without this fix the error can be reproduced in a container with `flytekit` 0.14.x with the following:
```
root@4a9ab1c1ada7:/usr/local/bin# /usr/local/bin/python /usr/local/bin/flytekit_sagemaker_runner.py --__FLYTE_CMD_0_pyflyte-execute__ __FLYTE_CMD_DUMMY_VALUE__ --__FLYTE_CMD_10_s3://lyft-modelbuilder/88/q8i35ntlmg-jadoo-task-0__ __FLYTE_CMD_DUMMY_VALUE__ --__FLYTE_CMD_1_--task-module__ __FLYTE_CMD_DUMMY_VALUE__ --__FLYTE_CMD_2_jadoo.flyte__ __FLYTE_CMD_DUMMY_VALUE__ --__FLYTE_CMD_3_--task-name__ __FLYTE_CMD_DUMMY_VALUE__ --__FLYTE_CMD_4_jadoo_training_task__ __FLYTE_CMD_DUMMY_VALUE__ --__FLYTE_CMD_5_--inputs__ __FLYTE_CMD_DUMMY_VALUE__ --__FLYTE_CMD_6_s3://lyft-modelbuilder/metadata/propeller/production/avmlworkflows-development-q8i35ntlmg/jadoo-task/data/inputs.pb__ __FLYTE_CMD_DUMMY_VALUE__ --__FLYTE_CMD_7_--output-prefix__ __FLYTE_CMD_DUMMY_VALUE__ --__FLYTE_CMD_8_s3://lyft-modelbuilder/metadata/propeller/production/avmlworkflows-development-q8i35ntlmg/jadoo-task/data/0__ __FLYTE_CMD_DUMMY_VALUE__ --__FLYTE_CMD_9_--raw-output-data-prefix__ __FLYTE_CMD_DUMMY_VALUE__ --__FLYTE_ENV_VAR_FLYTE_INTERNAL_CONFIGURATION_PATH__ /opt/avjadoo/flytekit.config --__FLYTE_ENV_VAR_FLYTE_INTERNAL_DOMAIN__ development --__FLYTE_ENV_VAR_FLYTE_INTERNAL_IMAGE__ 173840052742.dkr.ecr.us-east-1.amazonaws.com/avmlworkflows:abain_jadoo_1604522520 --__FLYTE_ENV_VAR_FLYTE_INTERNAL_PROJECT__ avmlworkflows --__FLYTE_ENV_VAR_FLYTE_INTERNAL_VERSION__ abain_jadoo_1604522520 --__FLYTE_ENV_VAR_FLYTE_STATSD_DISABLED__ True

Error: --raw-output-data-prefix option requires an argument
Traceback (most recent call last):
  File "/usr/local/bin/flytekit_sagemaker_runner.py", line 94, in <module>
    run(sys.argv)
  File "/usr/local/bin/flytekit_sagemaker_runner.py", line 90, in run
    subprocess.run(flyte_cmd, stdout=sys.stdout, stderr=sys.stderr, encoding="utf-8", check=True)
  File "/usr/local/lib/python3.8/subprocess.py", line 512, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['pyflyte-execute', '--task-module', 's3://lyft-modelbuilder/88/q8i35ntlmg-jadoo-task-0', 'jadoo.flyte', '--task-name', 'jadoo_training_task', '--inputs', 's3://lyft-modelbuilder/metadata/propeller/production/avmlworkflows-development-q8i35ntlmg/jadoo-task/data/inputs.pb', '--output-prefix', 's3://lyft-modelbuilder/metadata/propeller/production/avmlworkflows-development-q8i35ntlmg/jadoo-task/data/0', '--raw-output-data-prefix']' returned non-zero exit status 2.
```
I made this fix to my local container and verified that now the command executed with `subprocess` is formatted correctly:
```
root@4a9ab1c1ada7:/usr/local/bin# /usr/local/bin/python /usr/local/bin/flytekit_sagemaker_runner.py --__FLYTE_CMD_0_pyflyte-execute__ __FLYTE_CMD_DUMMY_VALUE__ --__FLYTE_CMD_10_s3://lyft-modelbuilder/88/q8i35ntlmg-jadoo-task-0__ __FLYTE_CMD_DUMMY_VALUE__ --__FLYTE_CMD_1_--task-module__ __FLYTE_CMD_DUMMY_VALUE__ --__FLYTE_CMD_2_jadoo.flyte__ __FLYTE_CMD_DUMMY_VALUE__ --__FLYTE_CMD_3_--task-name__ __FLYTE_CMD_DUMMY_VALUE__ --__FLYTE_CMD_4_jadoo_training_task__ __FLYTE_CMD_DUMMY_VALUE__ --__FLYTE_CMD_5_--inputs__ __FLYTE_CMD_DUMMY_VALUE__ --__FLYTE_CMD_6_s3://lyft-modelbuilder/metadata/propeller/production/avmlworkflows-development-q8i35ntlmg/jadoo-task/data/inputs.pb__ __FLYTE_CMD_DUMMY_VALUE__ --__FLYTE_CMD_7_--output-prefix__ __FLYTE_CMD_DUMMY_VALUE__ --__FLYTE_CMD_8_s3://lyft-modelbuilder/metadata/propeller/production/avmlworkflows-development-q8i35ntlmg/jadoo-task/data/0__ __FLYTE_CMD_DUMMY_VALUE__ --__FLYTE_CMD_9_--raw-output-data-prefix__ __FLYTE_CMD_DUMMY_VALUE__ --__FLYTE_ENV_VAR_FLYTE_INTERNAL_CONFIGURATION_PATH__ /opt/avjadoo/flytekit.config --__FLYTE_ENV_VAR_FLYTE_INTERNAL_DOMAIN__ development --__FLYTE_ENV_VAR_FLYTE_INTERNAL_IMAGE__ 173840052742.dkr.ecr.us-east-1.amazonaws.com/avmlworkflows:abain_jadoo_1604522520 --__FLYTE_ENV_VAR_FLYTE_INTERNAL_PROJECT__ avmlworkflows --__FLYTE_ENV_VAR_FLYTE_INTERNAL_VERSION__ abain_jadoo_1604522520 --__FLYTE_ENV_VAR_FLYTE_STATSD_DISABLED__ True

Launching command: ['pyflyte-execute', '--task-module', 'jadoo.flyte', '--task-name', 'jadoo_training_task', '--inputs', 's3://lyft-modelbuilder/metadata/propeller/production/avmlworkflows-development-q8i35ntlmg/jadoo-task/data/inputs.pb', '--output-prefix', 's3://lyft-modelbuilder/metadata/propeller/production/avmlworkflows-development-q8i35ntlmg/jadoo-task/data/0', '--raw-output-data-prefix', 's3://lyft-modelbuilder/88/q8i35ntlmg-jadoo-task-0']
```
You can see that in the fixed version `'--raw-output-data-prefix', 's3://lyft-modelbuilder/88/q8i35ntlmg-jadoo-task-0'` displays at the end. In the broken version, this key and its value do not appear together in the command to be executed.

This change means that the code includes a direct dependency on `natsort`. We should update the `requirements.in` file AND include a dependency on `natsort` in `setup.py`. I'm now sure how these are done in `flytekit`, I may have to leave that up to the team.