### PR TITLE
Fast registration: Make download destination dir configurable

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,7 +2,7 @@ import logging as _logging
 
 import flytekit.plugins  # noqa: F401
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"
 logger = _logging.getLogger("flytekit")
 
 # create console handler and set level to debug

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -123,17 +123,21 @@ def execute_task_cmd(task_module, task_name, inputs, output_prefix, raw_output_d
 
 @_pass_through.command("pyflyte-fast-execute")
 @_click.option("--additional-distribution", required=False)
+@_click.option("--dest-dir", required=False)
 @_click.argument("task-execute-cmd", nargs=-1, type=_click.UNPROCESSED)
-def fast_execute_task_cmd(additional_distribution, task_execute_cmd):
+def fast_execute_task_cmd(additional_distribution, dest_dir, task_execute_cmd):
     """
     Downloads a compressed code distribution specified by additional-distribution and then calls the underlying
     task execute command for the updated code.
     :param Text additional_distribution:
+    :param Text dest_dir:
     :param task_execute_cmd:
     :return:
     """
     if additional_distribution is not None:
-        _download_distribution(additional_distribution, _pathlib.Path(_os.getcwd()))
+        if not dest_dir:
+            dest_dir = _os.getcwd()
+        _download_distribution(additional_distribution, _pathlib.Path(dest_dir))
 
     # Use the commandline to run the task execute command rather than calling it directly in python code
     # since the current runtime bytecode references the older user code, rather than the downloaded distribution.

--- a/flytekit/common/tasks/sdk_runnable.py
+++ b/flytekit/common/tasks/sdk_runnable.py
@@ -447,14 +447,10 @@ class SdkRunnableTask(_base_task.SdkTask, metaclass=_sdk_bases.ExtendedSdkType):
 
         original_container = self.container
         container = _copy.deepcopy(original_container)
-        args = [
-            "pyflyte-fast-execute",
-            "--additional-distribution",
-            additional_distribution,
-            "--dest-dir",
-            dest_dir,
-            "--",
-        ] + container.args
+        args = ["pyflyte-fast-execute", "--additional-distribution", additional_distribution]
+        if dest_dir:
+            args += ["--dest-dir", dest_dir]
+        args += ["--"] + container.args
         container._args = args
         self._container = container
 

--- a/flytekit/common/tasks/sdk_runnable.py
+++ b/flytekit/common/tasks/sdk_runnable.py
@@ -423,7 +423,7 @@ class SdkRunnableTask(_base_task.SdkTask, metaclass=_sdk_bases.ExtendedSdkType):
         }
 
     @_exception_scopes.system_entry_point
-    def fast_register(self, project, domain, name, digest, additional_distribution) -> str:
+    def fast_register(self, project, domain, name, digest, additional_distribution, dest_dir) -> str:
         """
         The fast register call essentially hijacks the task container commandline.
         Say an existing task container definition had a commandline like so:
@@ -441,12 +441,20 @@ class SdkRunnableTask(_base_task.SdkTask, metaclass=_sdk_bases.ExtendedSdkType):
         :param Text name: The name to give this task.
         :param Text digest: The version in which to register this task.
         :param Text additional_distribution: User-specified location for remote source code distribution.
+        :param Text The optional location for where to install the additional distribution at runtime
         :rtype: Text: Registered identifier.
         """
 
         original_container = self.container
         container = _copy.deepcopy(original_container)
-        args = ["pyflyte-fast-execute", "--additional-distribution", additional_distribution, "--"] + container.args
+        args = [
+            "pyflyte-fast-execute",
+            "--additional-distribution",
+            additional_distribution,
+            "--dest-dir",
+            dest_dir,
+            "--",
+        ] + container.args
         container._args = args
         self._container = container
 


### PR DESCRIPTION
# TL;DR
To support using pyflyte outside of the container, this change adds a `dest-dir` param to fast-registration so code distributions can be installed wherever a user decides.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
https://docs.google.com/document/d/1n7DmKXaOv8dAb9eHD4TKqka6FsdJNs3Tugpf1I6nvMg/edit?usp=sharing

## Tracking Issue
https://github.com/lyft/flyte/issues/554

## Follow-up issue
_NA_
