### PR TITLE
Properly handle packages that are single python files

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,7 +2,7 @@ import logging as _logging
 
 import flytekit.plugins  # noqa: F401
 
-__version__ = "0.15.1"
+__version__ = "0.15.2"
 logger = _logging.getLogger("flytekit")
 
 # create console handler and set level to debug

--- a/flytekit/tools/module_loader.py
+++ b/flytekit/tools/module_loader.py
@@ -12,6 +12,11 @@ def iterate_modules(pkgs):
     for package_name in pkgs:
         package = importlib.import_module(package_name)
         yield package
+
+        # Check if package is a python file. If so, there is no reason to walk.
+        if not hasattr(package, "__path__"):
+            continue
+
         for _, name, _ in pkgutil.walk_packages(package.__path__, prefix="{}.".format(package_name)):
             yield importlib.import_module(name)
 

--- a/tests/flytekit/unit/tools/test_module_loader.py
+++ b/tests/flytekit/unit/tools/test_module_loader.py
@@ -34,3 +34,6 @@ def test_module_loading():
 
         # Not a sufficient test but passes for now
         assert sum(1 for _ in module_loader.iterate_modules(["top"])) == 6
+        assert [
+            pkg.__file__ for pkg in module_loader.iterate_modules(["top.a", "top.middle.a", "top.middle.bottom.a"])
+        ] == [os.path.join(lvl, "a.py") for lvl in (top_level, middle_level, bottom_level)]


### PR DESCRIPTION
# TL;DR
Adds support for single python files in the `sdk.workflow_packages` field of flyte configuration file.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Skip walking packages if they don't have a `__path__` variable.

## Tracking Issue
https://github.com/lyft/flyte/issues/623

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
