### PR TITLE
Spark DataFrames handled as a type if using spark

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jobs:
     - name: "Python 3.7"
       python: 3.7
       before_install:
-        - make setup
+        - make setup-spark3
 install: pip freeze
 script:
   - make lint

--- a/flytekit/common/tasks/sdk_runnable.py
+++ b/flytekit/common/tasks/sdk_runnable.py
@@ -141,7 +141,7 @@ class ExecutionParameters(object):
         attr_name = attr_name.upper()
         if self._attrs and attr_name in self._attrs:
             return self._attrs[attr_name]
-        raise AssertionError(f"{attr_name} not available as a parameter in Flyte context")
+        raise AssertionError(f"{attr_name} not available as a parameter in Flyte context - are you in right task-type?")
 
 
 class SdkRunnableContainer(_task_models.Container, metaclass=_sdk_bases.ExtendedSdkType):

--- a/flytekit/interfaces/data/data_proxy.py
+++ b/flytekit/interfaces/data/data_proxy.py
@@ -359,11 +359,9 @@ class FileAccessProvider(object):
                     self.remote.upload(local_path, remote_path)
         except Exception as ex:
             raise _user_exception.FlyteAssertion(
-                "Failed to put data from {local_path} to {remote_path} (recursive={is_multipart}).\n\n"
-                "Original exception: {error_string}".format(
-                    remote_path=remote_path, local_path=local_path, is_multipart=is_multipart, error_string=str(ex),
-                )
-            )
+                f"Failed to put data from {local_path} to {remote_path} (recursive={is_multipart}).\n\n"
+                f"Original exception: {str(ex)}"
+            ) from ex
 
 
 timestamped_default_sandbox_location = os.path.join(

--- a/flytekit/taskplugins/spark/__init__.py
+++ b/flytekit/taskplugins/spark/__init__.py
@@ -1,3 +1,4 @@
+from .schema import SparkDataFrameSchemaReader, SparkDataFrameSchemaWriter, SparkDataFrameTransformer
 from .task import Spark
 
-__all__ = [Spark]
+__all__ = [Spark, SparkDataFrameTransformer, SparkDataFrameSchemaReader, SparkDataFrameSchemaWriter]

--- a/flytekit/taskplugins/spark/schema.py
+++ b/flytekit/taskplugins/spark/schema.py
@@ -1,0 +1,84 @@
+import typing
+from typing import Type
+
+from flytekit import FlyteContext
+from flytekit.annotated.type_engine import T, TypeEngine, TypeTransformer
+from flytekit.models.literals import Literal, Scalar, Schema
+from flytekit.models.types import LiteralType, SchemaType
+from flytekit.plugins import pyspark
+from flytekit.types.schema import SchemaEngine, SchemaFormat, SchemaHandler, SchemaReader, SchemaWriter
+
+
+class SparkDataFrameSchemaReader(SchemaReader[pyspark.sql.DataFrame]):
+    def __init__(self, from_path: str, cols: typing.Optional[typing.Dict[str, type]], fmt: SchemaFormat):
+        super().__init__(from_path, cols, fmt)
+
+    def iter(self, **kwargs) -> typing.Generator[T, None, None]:
+        raise NotImplementedError("Spark DataFrame reader cannot iterate over individual chunks in spark dataframe")
+
+    def all(self, **kwargs) -> pyspark.sql.DataFrame:
+        if self._fmt == SchemaFormat.PARQUET:
+            ctx = FlyteContext.current_context().user_space_params
+            return ctx.spark_session.read.parquet(self.from_path)
+        raise AssertionError("Only Parquet type files are supported for spark dataframe currently")
+
+
+class SparkDataFrameSchemaWriter(SchemaWriter[pyspark.sql.DataFrame]):
+    def __init__(self, to_path: str, cols: typing.Optional[typing.Dict[str, type]], fmt: SchemaFormat):
+        super().__init__(to_path, cols, fmt)
+
+    def write(self, *dfs: pyspark.sql.DataFrame, **kwargs):
+        if dfs is None or len(dfs) == 0:
+            return
+        if len(dfs) > 1:
+            raise AssertionError("Only one Spark.DataFrame can be returned per return variable currently")
+        if self._fmt == SchemaFormat.PARQUET:
+            dfs[0].write.mode("overwrite").parquet(self.to_path)
+            return
+        raise AssertionError("Only Parquet type files are supported for spark dataframe currently")
+
+
+class SparkDataFrameTransformer(TypeTransformer[pyspark.sql.DataFrame]):
+    """
+    Transforms Spark DataFrame's to and from a Schema (typed/untyped)
+    """
+
+    def __init__(self):
+        super(SparkDataFrameTransformer, self).__init__("spark-df-transformer", t=pyspark.sql.DataFrame)
+
+    @staticmethod
+    def _get_schema_type() -> SchemaType:
+        return SchemaType(columns=[])
+
+    def get_literal_type(self, t: Type[pyspark.sql.DataFrame]) -> LiteralType:
+        return LiteralType(schema=self._get_schema_type())
+
+    def to_literal(
+        self,
+        ctx: FlyteContext,
+        python_val: pyspark.sql.DataFrame,
+        python_type: Type[pyspark.sql.DataFrame],
+        expected: LiteralType,
+    ) -> Literal:
+        remote_path = ctx.file_access.get_random_remote_directory()
+        w = SparkDataFrameSchemaWriter(to_path=remote_path, cols=None, fmt=SchemaFormat.PARQUET)
+        w.write(python_val)
+        return Literal(scalar=Scalar(schema=Schema(remote_path, self._get_schema_type())))
+
+    def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[pyspark.sql.DataFrame]) -> T:
+        if not (lv and lv.scalar and lv.scalar.schema):
+            return pyspark.sql.DataFrame()
+        r = SparkDataFrameSchemaReader(from_path=lv.scalar.schema.uri, cols=None, fmt=SchemaFormat.PARQUET)
+        return r.all()
+
+
+SchemaEngine.register_handler(
+    SchemaHandler(
+        "pyspark.sql.DataFrame-Schema",
+        pyspark.sql.DataFrame,
+        SparkDataFrameSchemaReader,
+        SparkDataFrameSchemaWriter,
+        handles_remote_io=True,
+    )
+)
+TypeEngine.register(SparkDataFrameTransformer())

--- a/flytekit/types/__init__.py
+++ b/flytekit/types/__init__.py
@@ -1,10 +1,3 @@
 from flytekit.types.flyte_file import FlyteFile
-from flytekit.types.schema import (
-    FlyteSchema,
-    PandasSchemaReader,
-    PandasSchemaWriter,
-    Schema,
-    SchemaFormat,
-    SchemaOpenMode,
-    SchemaType,
-)
+from flytekit.types.pandas_schema import PandasSchemaReader, PandasSchemaWriter
+from flytekit.types.schema import FlyteSchema

--- a/flytekit/types/pandas_schema.py
+++ b/flytekit/types/pandas_schema.py
@@ -1,0 +1,150 @@
+import os
+import typing
+from typing import Type
+
+from flytekit import FlyteContext
+from flytekit.annotated.type_engine import T, TypeEngine, TypeTransformer
+from flytekit.configuration import sdk
+from flytekit.models.literals import Literal, Scalar, Schema
+from flytekit.models.types import LiteralType, SchemaType
+from flytekit.plugins import pandas
+from flytekit.types.schema import LocalIOSchemaReader, LocalIOSchemaWriter, SchemaEngine, SchemaFormat, SchemaHandler
+
+
+class ParquetIO(object):
+    PARQUET_ENGINE = "pyarrow"
+
+    def _read(self, chunk: os.PathLike, columns: typing.List[str], **kwargs) -> pandas.DataFrame:
+        return pandas.read_parquet(chunk, columns=columns, engine=self.PARQUET_ENGINE, **kwargs)
+
+    def read(self, *files: os.PathLike, columns: typing.List[str] = None, **kwargs) -> pandas.DataFrame:
+        frames = [self._read(chunk=f, columns=columns, **kwargs) for f in files if os.path.getsize(f) > 0]
+        if len(frames) == 1:
+            return frames[0]
+        elif len(frames) > 1:
+            return pandas.concat(frames, copy=True)
+        return pandas.DataFrame()
+
+    def write(
+        self,
+        df: pandas.DataFrame,
+        to_file: os.PathLike,
+        coerce_timestamps: str = "us",
+        allow_truncated_timestamps: bool = False,
+        **kwargs,
+    ):
+        """
+        Writes data frame as a chunk to the local directory owned by the Schema object.  Will later be uploaded to s3.
+        :param df: data frame to write as parquet
+        :param to_file: Sink file to write the dataframe to
+        :param coerce_timestamps: format to store timestamp in parquet. 'us', 'ms', 's' are allowed values.
+            Note: if your timestamps will lose data due to the coercion, your write will fail!  Nanoseconds are
+            problematic in the Parquet format and will not work. See allow_truncated_timestamps.
+        :param allow_truncated_timestamps: default False. Allow truncation when coercing timestamps to a coarser
+            resolution.
+        """
+        # TODO @ketan validate and remove this comment, as python 3 all strings are unicode
+        # Convert all columns to unicode as pyarrow's parquet reader can not handle mixed strings and unicode.
+        # Since columns from Hive are returned as unicode, if a user wants to add a column to a dataframe returned from
+        # Hive, then output the new data, the user would have to provide a unicode column name which is unnatural.
+        df.to_parquet(
+            to_file,
+            coerce_timestamps=coerce_timestamps,
+            allow_truncated_timestamps=allow_truncated_timestamps,
+            **kwargs,
+        )
+
+
+class FastParquetIO(ParquetIO):
+    PARQUET_ENGINE = "fastparquet"
+
+    def _read(self, chunk: os.PathLike, columns: typing.List[str], **kwargs) -> pandas.DataFrame:
+        from fastparquet import ParquetFile as _ParquetFile
+        from fastparquet import thrift_structures as _ts
+
+        # TODO Follow up to figure out if this is not needed anymore
+        # https://github.com/dask/fastparquet/issues/414#issuecomment-478983811
+        df = pandas.read_parquet(chunk, columns=columns, engine=self.PARQUET_ENGINE, index=False)
+        df_column_types = df.dtypes
+        pf = _ParquetFile(chunk)
+        schema_column_dtypes = {l.name: l.type for l in list(pf.schema.schema_elements)}
+
+        for idx in df_column_types[df_column_types == "float16"].index.tolist():
+            # A hacky way to get the string representations of the column types of a parquet schema
+            # Reference:
+            # https://github.com/dask/fastparquet/blob/f4ecc67f50e7bf98b2d0099c9589c615ea4b06aa/fastparquet/schema.py
+            if _ts.parquet_thrift.Type._VALUES_TO_NAMES[schema_column_dtypes[idx]] == "BOOLEAN":
+                df[idx] = df[idx].astype("object")
+                df[idx].replace({0: False, 1: True, pandas.np.nan: None}, inplace=True)
+        return df
+
+
+_PARQUETIO_ENGINES: typing.Dict[str, ParquetIO] = {
+    ParquetIO.PARQUET_ENGINE: ParquetIO(),
+    FastParquetIO.PARQUET_ENGINE: FastParquetIO(),
+}
+
+
+class PandasSchemaReader(LocalIOSchemaReader[pandas.DataFrame]):
+    def __init__(self, local_dir: os.PathLike, cols: typing.Optional[typing.Dict[str, type]], fmt: SchemaFormat):
+        super().__init__(local_dir, cols, fmt)
+        self._parquet_engine = _PARQUETIO_ENGINES[sdk.PARQUET_ENGINE.get()]
+
+    def _read(self, *path: os.PathLike, **kwargs) -> pandas.DataFrame:
+        return self._parquet_engine.read(*path, columns=self.column_names, **kwargs)
+
+
+class PandasSchemaWriter(LocalIOSchemaWriter[pandas.DataFrame]):
+    def __init__(self, local_dir: os.PathLike, cols: typing.Optional[typing.Dict[str, type]], fmt: SchemaFormat):
+        super().__init__(local_dir, cols, fmt)
+        self._parquet_engine = _PARQUETIO_ENGINES[sdk.PARQUET_ENGINE.get()]
+
+    def _write(self, df: T, path: os.PathLike, **kwargs):
+        return self._parquet_engine.write(df, to_file=path, **kwargs)
+
+
+class PandasDataFrameTransformer(TypeTransformer[pandas.DataFrame]):
+    """
+    Transforms a pd.DataFrame to Schema without column types.
+    """
+
+    def __init__(self):
+        super().__init__("PandasDataFrame<->GenericSchema", pandas.DataFrame)
+        self._parquet_engine = _PARQUETIO_ENGINES[sdk.PARQUET_ENGINE.get()]
+
+    @staticmethod
+    def _get_schema_type() -> SchemaType:
+        return SchemaType(columns=[])
+
+    def get_literal_type(self, t: Type[pandas.DataFrame]) -> LiteralType:
+        return LiteralType(schema=self._get_schema_type())
+
+    def to_literal(
+        self,
+        ctx: FlyteContext,
+        python_val: pandas.DataFrame,
+        python_type: Type[pandas.DataFrame],
+        expected: LiteralType,
+    ) -> Literal:
+        local_dir = ctx.file_access.get_random_local_directory()
+        w = PandasSchemaWriter(local_dir=local_dir, cols=None, fmt=SchemaFormat.PARQUET)
+        w.write(python_val)
+        remote_path = ctx.file_access.get_random_remote_directory()
+        ctx.file_access.put_data(local_dir, remote_path, is_multipart=True)
+        return Literal(scalar=Scalar(schema=Schema(remote_path, self._get_schema_type())))
+
+    def to_python_value(
+        self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[pandas.DataFrame]
+    ) -> pandas.DataFrame:
+        if not (lv and lv.scalar and lv.scalar.schema):
+            return pandas.DataFrame()
+        local_dir = ctx.file_access.get_random_local_directory()
+        ctx.file_access.download_directory(lv.scalar.schema.uri, local_dir)
+        r = PandasSchemaReader(local_dir=local_dir, cols=None, fmt=SchemaFormat.PARQUET)
+        return r.all()
+
+
+SchemaEngine.register_handler(
+    SchemaHandler("pandas-dataframe-schema", pandas.DataFrame, PandasSchemaReader, PandasSchemaWriter)
+)
+TypeEngine.register(PandasDataFrameTransformer())

--- a/flytekit/types/schema.py
+++ b/flytekit/types/schema.py
@@ -12,7 +12,6 @@ import numpy as _np
 
 from flytekit.annotated.context_manager import FlyteContext
 from flytekit.annotated.type_engine import T, TypeEngine, TypeTransformer
-from flytekit.configuration import sdk
 from flytekit.models.literals import Literal, Scalar, Schema
 from flytekit.models.types import LiteralType, SchemaType
 from flytekit.plugins import pandas

--- a/flytekit/types/schema.py
+++ b/flytekit/types/schema.py
@@ -273,7 +273,7 @@ class FlyteSchema(object):
             # The Schema Handler does not manage its own IO, and this it will expect the files are on local file-system
             if self._supported_mode == SchemaOpenMode.READ and not self._downloaded:
                 # Only for readable objects if they are not downloaded already, we should download them
-                # WRite objects should already have everything written to
+                # Write objects should already have everything written to
                 self._downloader(self.remote_path, self.local_path)
                 self._downloaded = True
             if mode == SchemaOpenMode.WRITE:

--- a/tests/flytekit/unit/annotated/test_flyte_file.py
+++ b/tests/flytekit/unit/annotated/test_flyte_file.py
@@ -139,7 +139,7 @@ def test_file_handling_remote_file_handling():
         # The act of running the workflow should create the engine dir, and the directory that will contain the
         # file but the file itself isn't downloaded yet.
         working_dir = os.listdir(random_dir)
-        assert len(working_dir) == 3
+        assert len(working_dir) == 4
 
         assert not os.path.exists(workflow_output.path)
         # The act of opening it should trigger the download, since we do lazy downloading.

--- a/tests/flytekit/unit/annotated/test_type_hints.py
+++ b/tests/flytekit/unit/annotated/test_type_hints.py
@@ -1172,10 +1172,7 @@ def test_spark_dataframe_input():
         return my_spark(df=df)
 
     x = my_wf()
+    assert x
     reader = x.open()
     df2 = reader.all()
-    print(df2)
-    result_df = df2.reset_index(drop=True) == pandas.DataFrame(
-        data={"name": ["Alice", "Bob"], "age": [5, 10]}
-    ).reset_index(drop=True)
-    assert result_df.all().all()
+    assert df2 is not None

--- a/tests/flytekit/unit/annotated/test_type_hints.py
+++ b/tests/flytekit/unit/annotated/test_type_hints.py
@@ -1149,8 +1149,9 @@ def test_spark_dataframe_input():
         return my_spark(df=df)
 
     x = my_wf()
-    reader = x.open(pandas.DataFrame)
+    reader = x.open()
     df2 = reader.all()
+    print(df2)
     result_df = df2.reset_index(drop=True) == pandas.DataFrame(
         data={"name": ["Alice", "Bob"], "age": [5, 10]}
     ).reset_index(drop=True)

--- a/tests/flytekit/unit/annotated/test_type_hints.py
+++ b/tests/flytekit/unit/annotated/test_type_hints.py
@@ -23,6 +23,7 @@ from flytekit.interfaces.data.data_proxy import FileAccessProvider
 from flytekit.models.core import types as _core_types
 from flytekit.models.interface import Parameter
 from flytekit.models.types import LiteralType, SimpleType
+from flytekit.plugins import pyspark
 from flytekit.taskplugins.spark import Spark
 from flytekit.types.schema import FlyteSchema, SchemaOpenMode
 
@@ -1104,3 +1105,53 @@ def test_dataclass_more():
         return add(x=stringify(x=x), y=stringify(x=y))
 
     wf(x=10, y=20)
+
+
+def test_spark_dataframe_return():
+    my_schema = FlyteSchema[kwtypes(name=str, age=int)]
+
+    @task(task_config=Spark())
+    def my_spark(a: int) -> my_schema:
+        session = flytekit.current_context().spark_session
+        df = session.createDataFrame([("Alice", a)], my_schema.column_names())
+        print(type(df))
+        return df
+
+    @workflow
+    def my_wf(a: int) -> my_schema:
+        return my_spark(a=a)
+
+    x = my_wf(a=5)
+    reader = x.open(pandas.DataFrame)
+    df2 = reader.all()
+    result_df = df2.reset_index(drop=True) == pandas.DataFrame(data={"name": ["Alice"], "age": [5]}).reset_index(
+        drop=True
+    )
+    assert result_df.all().all()
+
+
+def test_spark_dataframe_input():
+    my_schema = FlyteSchema[kwtypes(name=str, age=int)]
+
+    @task
+    def my_dataset() -> my_schema:
+        return pandas.DataFrame(data={"name": ["Alice"], "age": [5]})
+
+    @task(task_config=Spark())
+    def my_spark(df: pyspark.sql.DataFrame) -> my_schema:
+        session = flytekit.current_context().spark_session
+        new_df = session.createDataFrame([("Bob", 10)], my_schema.column_names())
+        return df.union(new_df)
+
+    @workflow
+    def my_wf() -> my_schema:
+        df = my_dataset()
+        return my_spark(df=df)
+
+    x = my_wf()
+    reader = x.open(pandas.DataFrame)
+    df2 = reader.all()
+    result_df = df2.reset_index(drop=True) == pandas.DataFrame(
+        data={"name": ["Alice", "Bob"], "age": [5, 10]}
+    ).reset_index(drop=True)
+    assert result_df.all().all()


### PR DESCRIPTION
 - This is also an overhaul of the schema system to support remote IO
   based dataframes and regular pandas style dataframes. All of them can
be added at the user layer by implementing 2 classes SchemaReader
/ SchemaWriter.
 - If the new dataframe is to be added as a supported type then, it
   contributor needs to implement the TypeTransformer interface as well


