### PR TITLE
Proper setting of fetched entities

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,7 +2,7 @@ import logging as _logging
 
 import flytekit.plugins  # noqa: F401
 
-__version__ = "0.15.2"
+__version__ = "0.15.3"
 logger = _logging.getLogger("flytekit")
 
 # create console handler and set level to debug

--- a/flytekit/common/launch_plan.py
+++ b/flytekit/common/launch_plan.py
@@ -51,7 +51,7 @@ class SdkLaunchPlan(
         :param flytekit.models.launch_plan.LaunchPlanSpec model:
         :rtype: SdkLaunchPlan
         """
-        return cls(
+        launch_plan = cls(
             workflow_id=_identifier.Identifier.promote_from_model(model.workflow_id),
             default_inputs=_interface_models.ParameterMap(
                 {
@@ -66,6 +66,9 @@ class SdkLaunchPlan(
             auth_role=model.auth_role,
             raw_output_data_config=model.raw_output_data_config,
         )
+        launch_plan.assign_name(model.workflow_id.name)
+        launch_plan._has_registered = True
+        return launch_plan
 
     @_exception_scopes.system_entry_point
     def register(self, project, domain, name, version):

--- a/flytekit/common/launch_plan.py
+++ b/flytekit/common/launch_plan.py
@@ -51,7 +51,7 @@ class SdkLaunchPlan(
         :param flytekit.models.launch_plan.LaunchPlanSpec model:
         :rtype: SdkLaunchPlan
         """
-        launch_plan = cls(
+        return cls(
             workflow_id=_identifier.Identifier.promote_from_model(model.workflow_id),
             default_inputs=_interface_models.ParameterMap(
                 {
@@ -66,9 +66,6 @@ class SdkLaunchPlan(
             auth_role=model.auth_role,
             raw_output_data_config=model.raw_output_data_config,
         )
-        launch_plan.assign_name(model.workflow_id.name)
-        launch_plan._has_registered = True
-        return launch_plan
 
     @_exception_scopes.system_entry_point
     def register(self, project, domain, name, version):
@@ -119,6 +116,8 @@ class SdkLaunchPlan(
 
         sdk_lp = cls.promote_from_model(lp.spec)
         sdk_lp._id = lp.id
+        sdk_lp.assign_name(name)
+        sdk_lp._has_registered = True
 
         # TODO: Add a test for this, and this function as a whole
         wf_id = sdk_lp.workflow_id

--- a/flytekit/common/launch_plan.py
+++ b/flytekit/common/launch_plan.py
@@ -123,7 +123,6 @@ class SdkLaunchPlan(
         wf_id = sdk_lp.workflow_id
         lp_wf = _workflow.SdkWorkflow.fetch(wf_id.project, wf_id.domain, wf_id.name, wf_id.version)
         sdk_lp._interface = lp_wf.interface
-        sdk_lp._has_registered = True
         return sdk_lp
 
     @_exception_scopes.system_entry_point

--- a/flytekit/common/tasks/task.py
+++ b/flytekit/common/tasks/task.py
@@ -191,6 +191,7 @@ class SdkTask(
 
         sdk_task = cls.promote_from_model(admin_task.closure.compiled_task.template)
         sdk_task._id = task_id
+        sdk_task.assign_name(name)
         sdk_task._has_registered = True
         return sdk_task
 

--- a/flytekit/common/workflow.py
+++ b/flytekit/common/workflow.py
@@ -135,6 +135,7 @@ class SdkWorkflow(
         task_map = {t.template.id: t.template for t in cwc.tasks}
         sdk_workflow = cls.promote_from_model(primary_template, sub_workflow_map, task_map)
         sdk_workflow._id = workflow_id
+        sdk_workflow.assign_name(name)
         sdk_workflow._has_registered = True
         return sdk_workflow
 

--- a/tests/flytekit/unit/common_tests/test_task.py
+++ b/tests/flytekit/unit/common_tests/test_task.py
@@ -1,0 +1,38 @@
+from mock import patch as _patch
+
+from flytekit.common.tasks.task import SdkTask
+from flytekit.models import interface as _interface
+from flytekit.models import task as _task_model
+from flytekit.models import types as _types
+from flytekit.models.core import identifier as _identifier
+from flytekit.models.task import CompiledTask, Task, TaskClosure
+from tests.flytekit.unit.common_tests.test_workflow_promote import get_sample_container, get_sample_task_metadata
+
+
+@_patch("flytekit.engines.flyte.engine.get_client")
+def test_task_fetch_sets_correct_things(mock_get_client):
+    int_type = _types.LiteralType(_types.SimpleType.INTEGER)
+    task_interface = _interface.TypedInterface(
+        # inputs
+        {"a": _interface.Variable(int_type, "description1")},
+        # outputs
+        {"b": _interface.Variable(int_type, "description2"), "c": _interface.Variable(int_type, "description3")},
+    )
+    # Since the promotion of a workflow requires retrieving the task from Admin, we mock the SdkTask to return
+    task_id = _identifier.Identifier(
+        _identifier.ResourceType.TASK, "project", "domain", "test.task.for.fetch", "version",
+    )
+    task_template = _task_model.TaskTemplate(
+        task_id,
+        "python_container",
+        get_sample_task_metadata(),
+        task_interface,
+        custom={},
+        container=get_sample_container(),
+    )
+
+    task_from_client = Task(id=task_id, closure=TaskClosure(compiled_task=CompiledTask(template=task_template)))
+    mock_get_client.return_value.get_task.return_value = task_from_client
+    fetched = SdkTask.fetch("project", "domain", "test.task.for.fetch", "version")
+    assert fetched._has_registered
+    assert fetched.platform_valid_name == "test.task.for.fetch"

--- a/tests/flytekit/unit/common_tests/test_task.py
+++ b/tests/flytekit/unit/common_tests/test_task.py
@@ -1,4 +1,4 @@
-from mock import patch as _patch
+from mock import patch
 
 from flytekit.common.tasks.task import SdkTask
 from flytekit.models import interface as _interface
@@ -9,7 +9,7 @@ from flytekit.models.task import CompiledTask, Task, TaskClosure
 from tests.flytekit.unit.common_tests.test_workflow_promote import get_sample_container, get_sample_task_metadata
 
 
-@_patch("flytekit.engines.flyte.engine.get_client")
+@patch("flytekit.engines.flyte.engine.get_client")
 def test_task_fetch_sets_correct_things(mock_get_client):
     int_type = _types.LiteralType(_types.SimpleType.INTEGER)
     task_interface = _interface.TypedInterface(


### PR DESCRIPTION
# TL;DR
Entities fetched from the control plane don't behave the same as entities declared locally.  This change circumvents some of the behavior.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Please see the [Slack](https://flyte-org.slack.com/archives/CNMKCU6FR/p1607624069238500) conversation for background.  This was discovered when a user yielded a launch plan that was fetched from within a dynamic task.  The code in sdk_dynamic was attempting to assign a name to the fetched launch plan (which didn't work because the fetching was done inside a function). If it had been done outside the function, the name would've been set to the variable that the fetched launch plan was assigned to, which is even worse.

## Tracking Issue
NA

## Follow-up issue
NA
