### PR TITLE
Require at least py37

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,12 +86,11 @@ setup(
         "scripts/flytekit_sagemaker_runner.py",
     ],
     license="apache2",
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     classifiers=[
         "Intended Audience :: Developers",
         "Intended Audience :: System Administrators",
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Topic :: Software Development :: Libraries",


### PR DESCRIPTION
# TL;DR
Require at least Python 3.7.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The new API requires at least Python 3.7 to function.

## Tracking Issue
_NA_

## Follow-up issue
_NA_
