### PR TITLE
Fix tuple handling in condition branches

### DIFF
--- a/flytekit/annotated/promise.py
+++ b/flytekit/annotated/promise.py
@@ -229,7 +229,7 @@ class ConjunctionExpression(object):
         if self.op == ConjunctionOps.OR and l_eval is True:
             return True
 
-        r_eval = self.lhs.eval()
+        r_eval = self.rhs.eval()
         if self.op == ConjunctionOps.AND:
             return l_eval and r_eval
 

--- a/flytekit/annotated/promise.py
+++ b/flytekit/annotated/promise.py
@@ -384,6 +384,13 @@ def create_task_output(promises: Optional[Union[List[Promise], Promise]]) -> Opt
             val.with_overrides(*args, **kwargs)
             return self
 
+        @property
+        def ref(self):
+            for p in promises:
+                if p.ref:
+                    return p.ref
+            return None
+
     return Output(*promises)
 
 

--- a/tests/flytekit/unit/annotated/test_conditions.py
+++ b/tests/flytekit/unit/annotated/test_conditions.py
@@ -1,0 +1,48 @@
+from flytekit import workflow, task
+from flytekit.annotated.condition import conditional
+
+
+@task()
+def square(n: float) -> float:
+    """
+    Parameters:
+        n (float): name of the parameter for the task will be derived from the name of the input variable
+               the type will be automatically deduced to be Types.Integer
+
+    Return:
+        float: The label for the output will be automatically assigned and type will be deduced from the annotation
+
+    """
+    return n * n
+
+
+@task()
+def double(n: float) -> float:
+    """
+    Parameters:
+        n (float): name of the parameter for the task will be derived from the name of the input variable
+               the type will be automatically deduced to be Types.Integer
+
+    Return:
+        float: The label for the output will be automatically assigned and type will be deduced from the annotation
+
+    """
+    return 2 * n
+
+
+def test_condition_else_fail():
+    @workflow
+    def multiplier_2(my_input: float) -> float:
+        return (
+            conditional("fractions")
+                .if_((my_input > 0.1) & (my_input < 1.0))
+                .then(double(n=my_input))
+                .elif_((my_input > 1.0) & (my_input < 10.0))
+                .then(square(n=my_input))
+                .else_()
+                .fail("The input must be between 0 and 10")
+        )
+
+    res = multiplier_2(my_input=10)
+    print(f"Output of multiplier_2(my_input=10): {res}")
+    assert res != 20

--- a/tests/flytekit/unit/annotated/test_conditions.py
+++ b/tests/flytekit/unit/annotated/test_conditions.py
@@ -37,12 +37,12 @@ def test_condition_else_fail():
     def multiplier_2(my_input: float) -> float:
         return (
             conditional("fractions")
-                .if_((my_input > 0.1) & (my_input < 1.0))
-                .then(double(n=my_input))
-                .elif_((my_input > 1.0) & (my_input < 10.0))
-                .then(square(n=my_input))
-                .else_()
-                .fail("The input must be between 0 and 10")
+            .if_((my_input > 0.1) & (my_input < 1.0))
+            .then(double(n=my_input))
+            .elif_((my_input > 1.0) & (my_input < 10.0))
+            .then(square(n=my_input))
+            .else_()
+            .fail("The input must be between 0 and 10")
         )
 
     with pytest.raises(ValueError):

--- a/tests/flytekit/unit/annotated/test_conditions.py
+++ b/tests/flytekit/unit/annotated/test_conditions.py
@@ -1,4 +1,5 @@
 import typing
+
 import pytest
 
 from flytekit import task, workflow

--- a/tests/flytekit/unit/annotated/test_conditions.py
+++ b/tests/flytekit/unit/annotated/test_conditions.py
@@ -1,3 +1,5 @@
+import typing
+
 import pytest
 
 from flytekit import task, workflow
@@ -47,3 +49,57 @@ def test_condition_else_fail():
 
     with pytest.raises(ValueError):
         multiplier_2(my_input=10)
+
+
+def test_condition_sub_workflows():
+    @task()
+    def sum_div_sub(a: int, b: int) -> typing.NamedTuple("Outputs", sum=int, div=int, sub=int):
+        return a + b, a / b, a - b
+
+    @task()
+    def sum_sub(a: int, b: int) -> typing.NamedTuple("Outputs", sum=int, sub=int):
+        return a + b, a - b
+
+    @workflow
+    def sub_wf(a: int, b: int) -> (int, int):
+        return sum_sub(a=a, b=b)
+
+    @workflow
+    def math_ops(a: int, b: int) -> (int, int):
+        # Flyte will only make `sum` and `sub` available as outputs because they are common between all branches
+        sum, sub = (
+            conditional("noDivByZero")
+            .if_(a > b)
+            .then(sub_wf(a=a, b=b))
+            .else_()
+            .fail("Only positive results are allowed")
+        )
+
+        return sum, sub
+
+    x, y = math_ops(a=3, b=2)
+    assert x == 5
+    assert y == 1
+
+
+def test_condition_tuple_branches():
+    @task()
+    def sum_sub(a: int, b: int) -> typing.NamedTuple("Outputs", sum=int, sub=int):
+        return a + b, a - b
+
+    @workflow
+    def math_ops(a: int, b: int) -> (int, int):
+        # Flyte will only make `sum` and `sub` available as outputs because they are common between all branches
+        sum, sub = (
+            conditional("noDivByZero")
+            .if_(a > b)
+            .then(sum_sub(a=a, b=b))
+            .else_()
+            .fail("Only positive results are allowed")
+        )
+
+        return sum, sub
+
+    x, y = math_ops(a=3, b=2)
+    assert x == 5
+    assert y == 1

--- a/tests/flytekit/unit/annotated/test_conditions.py
+++ b/tests/flytekit/unit/annotated/test_conditions.py
@@ -1,6 +1,6 @@
 import pytest
 
-from flytekit import workflow, task
+from flytekit import task, workflow
 from flytekit.annotated.condition import conditional
 
 

--- a/tests/flytekit/unit/annotated/test_conditions.py
+++ b/tests/flytekit/unit/annotated/test_conditions.py
@@ -1,3 +1,5 @@
+import pytest
+
 from flytekit import workflow, task
 from flytekit.annotated.condition import conditional
 
@@ -43,6 +45,5 @@ def test_condition_else_fail():
                 .fail("The input must be between 0 and 10")
         )
 
-    res = multiplier_2(my_input=10)
-    print(f"Output of multiplier_2(my_input=10): {res}")
-    assert res != 20
+    with pytest.raises(ValueError):
+        multiplier_2(my_input=10)


### PR DESCRIPTION
# TL;DR
condition handling of tuples in tasks was broken because it assumed always a single Promise will be returned.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue
