### PR TITLE
Fix the output-persisting logic for CustomTrainingJobTask

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -2,7 +2,7 @@ import logging as _logging
 
 import flytekit.plugins  # noqa: F401
 
-__version__ = "0.15.3"
+__version__ = "0.15.4"
 logger = _logging.getLogger("flytekit")
 
 # create console handler and set level to debug

--- a/flytekit/common/tasks/sagemaker/custom_training_job_task.py
+++ b/flytekit/common/tasks/sagemaker/custom_training_job_task.py
@@ -115,6 +115,8 @@ class CustomTrainingJobTask(_sdk_runnable.SdkRunnableTask):
             working directory (with the names provided), which will in turn allow Flyte Propeller to push along the
             workflow.  Where as local engine will merely feed the outputs directly into the next node.
         """
+        distributed_context = (_sm_distribution.get_sagemaker_distributed_training_context_from_env()
+                               if self._is_distributed() else None)
         dist_training_task_specific_engine_context = _sm_distribution.DistributedTrainingEngineContext(
             execution_date=context.execution_date,
             tmp_dir=context.working_directory,
@@ -122,7 +124,7 @@ class CustomTrainingJobTask(_sdk_runnable.SdkRunnableTask):
             execution_id=context.execution_id,
             logging=context.logging,
             raw_output_data_prefix=context.raw_output_data_prefix,
-            distributed_training_context=_sm_distribution.get_sagemaker_distributed_training_context_from_env(),
+            distributed_training_context=distributed_context,
         )
 
         ret = super().execute(dist_training_task_specific_engine_context, inputs)

--- a/flytekit/common/tasks/sagemaker/custom_training_job_task.py
+++ b/flytekit/common/tasks/sagemaker/custom_training_job_task.py
@@ -133,8 +133,7 @@ class CustomTrainingJobTask(_sdk_runnable.SdkRunnableTask):
         if self._is_distributed() is False or (
             self._is_distributed()
             and self._output_persist_predicate
-            and self.output_persist_predicate(engine_context.distributed_training_context)
-            is True
+            and self.output_persist_predicate(engine_context.distributed_training_context) is True
         ):
             return ret
         else:
@@ -161,13 +160,13 @@ class CustomTrainingJobTask(_sdk_runnable.SdkRunnableTask):
         """
 
         wf_params = _sm_distribution.DistributedTrainingExecutionParam(
-                execution_date=context.execution_date,
-                # TODO: it might be better to consider passing the full struct
-                execution_id=_six.text_type(WorkflowExecutionIdentifier.promote_from_model(context.execution_id)),
-                stats=context.stats,
-                logging=context.logging,
-                tmp_dir=context.working_directory,
-                distributed_training_context=context.distributed_training_context,
-            )
+            execution_date=context.execution_date,
+            # TODO: it might be better to consider passing the full struct
+            execution_id=_six.text_type(WorkflowExecutionIdentifier.promote_from_model(context.execution_id)),
+            stats=context.stats,
+            logging=context.logging,
+            tmp_dir=context.working_directory,
+            distributed_training_context=context.distributed_training_context,
+        )
 
         return _exception_scopes.user_entry_point(self.task_function)(wf_params, **inputs)

--- a/flytekit/common/tasks/sagemaker/custom_training_job_task.py
+++ b/flytekit/common/tasks/sagemaker/custom_training_job_task.py
@@ -115,8 +115,9 @@ class CustomTrainingJobTask(_sdk_runnable.SdkRunnableTask):
             working directory (with the names provided), which will in turn allow Flyte Propeller to push along the
             workflow.  Where as local engine will merely feed the outputs directly into the next node.
         """
-        distributed_context = (_sm_distribution.get_sagemaker_distributed_training_context_from_env()
-                               if self._is_distributed() else None)
+        distributed_context = (
+            _sm_distribution.get_sagemaker_distributed_training_context_from_env() if self._is_distributed() else None
+        )
         dist_training_task_specific_engine_context = _sm_distribution.DistributedTrainingEngineContext(
             execution_date=context.execution_date,
             tmp_dir=context.working_directory,

--- a/flytekit/common/tasks/sagemaker/custom_training_job_task.py
+++ b/flytekit/common/tasks/sagemaker/custom_training_job_task.py
@@ -159,14 +159,15 @@ class CustomTrainingJobTask(_sdk_runnable.SdkRunnableTask):
             workflow.  Where as local engine will merely feed the outputs directly into the next node.
         """
 
-        wf_params = _sm_distribution.DistributedTrainingExecutionParam(
-            execution_date=context.execution_date,
-            # TODO: it might be better to consider passing the full struct
-            execution_id=_six.text_type(WorkflowExecutionIdentifier.promote_from_model(context.execution_id)),
-            stats=context.stats,
-            logging=context.logging,
-            tmp_dir=context.working_directory,
-            distributed_training_context=context.distributed_training_context,
+        return _exception_scopes.user_entry_point(self.task_function)(
+            _sm_distribution.DistributedTrainingExecutionParam(
+                execution_date=context.execution_date,
+                # TODO: it might be better to consider passing the full struct
+                execution_id=_six.text_type(WorkflowExecutionIdentifier.promote_from_model(context.execution_id)),
+                stats=context.stats,
+                logging=context.logging,
+                tmp_dir=context.working_directory,
+                distributed_training_context=context.distributed_training_context,
+            ),
+            **inputs
         )
-
-        return _exception_scopes.user_entry_point(self.task_function)(wf_params, **inputs)

--- a/flytekit/common/tasks/sagemaker/custom_training_job_task.py
+++ b/flytekit/common/tasks/sagemaker/custom_training_job_task.py
@@ -115,25 +115,29 @@ class CustomTrainingJobTask(_sdk_runnable.SdkRunnableTask):
             working directory (with the names provided), which will in turn allow Flyte Propeller to push along the
             workflow.  Where as local engine will merely feed the outputs directly into the next node.
         """
-        distributed_context = (
-            _sm_distribution.get_sagemaker_distributed_training_context_from_env() if self._is_distributed() else None
-        )
-        dist_training_task_specific_engine_context = _sm_distribution.DistributedTrainingEngineContext(
-            execution_date=context.execution_date,
-            tmp_dir=context.working_directory,
-            stats=context.stats,
-            execution_id=context.execution_id,
-            logging=context.logging,
-            raw_output_data_prefix=context.raw_output_data_prefix,
-            distributed_training_context=distributed_context,
-        )
+        if self._is_distributed():
 
-        ret = super().execute(dist_training_task_specific_engine_context, inputs)
+            distributed_context = (
+                _sm_distribution.get_sagemaker_distributed_training_context_from_env()
+            )
+            engine_context = _sm_distribution.DistributedTrainingEngineContext(
+                execution_date=context.execution_date,
+                tmp_dir=context.working_directory,
+                stats=context.stats,
+                execution_id=context.execution_id,
+                logging=context.logging,
+                raw_output_data_prefix=context.raw_output_data_prefix,
+                distributed_training_context=distributed_context,
+            )
+        else:
+            engine_context = context
+
+        ret = super().execute(engine_context, inputs)
 
         if self._is_distributed() is False or (
             self._is_distributed()
             and self._output_persist_predicate
-            and self.output_persist_predicate(dist_training_task_specific_engine_context.distributed_training_context)
+            and self.output_persist_predicate(engine_context.distributed_training_context)
             is True
         ):
             return ret
@@ -160,15 +164,24 @@ class CustomTrainingJobTask(_sdk_runnable.SdkRunnableTask):
             workflow.  Where as local engine will merely feed the outputs directly into the next node.
         """
 
-        return _exception_scopes.user_entry_point(self.task_function)(
-            _sm_distribution.DistributedTrainingExecutionParam(
-                execution_date=context.execution_date,
-                # TODO: it might be better to consider passing the full struct
-                execution_id=_six.text_type(WorkflowExecutionIdentifier.promote_from_model(context.execution_id)),
-                stats=context.stats,
-                logging=context.logging,
-                tmp_dir=context.working_directory,
-                distributed_training_context=context.distributed_training_context,
-            ),
-            **inputs
-        )
+        if self._is_distributed():
+            wf_params = _sm_distribution.DistributedTrainingExecutionParam(
+                    execution_date=context.execution_date,
+                    # TODO: it might be better to consider passing the full struct
+                    execution_id=_six.text_type(WorkflowExecutionIdentifier.promote_from_model(context.execution_id)),
+                    stats=context.stats,
+                    logging=context.logging,
+                    tmp_dir=context.working_directory,
+                    distributed_training_context=context.distributed_training_context,
+                )
+        else:
+            wf_params = _sdk_runnable.ExecutionParameters(
+                    execution_date=context.execution_date,
+                    # TODO: it might be better to consider passing the full struct
+                    execution_id=_six.text_type(WorkflowExecutionIdentifier.promote_from_model(context.execution_id)),
+                    stats=context.stats,
+                    logging=context.logging,
+                    tmp_dir=context.working_directory,
+                )
+
+        return _exception_scopes.user_entry_point(self.task_function)(wf_params, **inputs)

--- a/flytekit/common/tasks/sagemaker/custom_training_job_task.py
+++ b/flytekit/common/tasks/sagemaker/custom_training_job_task.py
@@ -127,7 +127,7 @@ class CustomTrainingJobTask(_sdk_runnable.SdkRunnableTask):
 
         ret = super().execute(dist_training_task_specific_engine_context, inputs)
 
-        if (
+        if self._is_distributed() is False or (
             self._is_distributed()
             and self._output_persist_predicate
             and self.output_persist_predicate(dist_training_task_specific_engine_context.distributed_training_context)

--- a/tests/flytekit/unit/sdk/tasks/test_sagemaker_tasks.py
+++ b/tests/flytekit/unit/sdk/tasks/test_sagemaker_tasks.py
@@ -324,9 +324,18 @@ class SingleNodeCustomTrainingJobTaskTests(unittest.TestCase):
             assert type(self._my_single_node_task) == CustomTrainingJobTask
 
     def test_output_persistence(self):
-        # execute the distributed task with its distributed_training_context == None
-        ret = self._my_single_node_task.execute(self._context, self._task_input)
-        assert _common_constants.OUTPUT_FILE_NAME in ret.keys()
+        # In single-node training on SageMaker, the distributed training env vars are still filled in
+        with mock.patch.dict(
+            _os.environ,
+            {
+                _sm_distribution.SM_ENV_VAR_CURRENT_HOST: "algo-0",
+                _sm_distribution.SM_ENV_VAR_HOSTS: '["algo-0"]',
+                _sm_distribution.SM_ENV_VAR_NETWORK_INTERFACE_NAME: "eth0",
+            },
+            clear=True,
+        ):
+            ret = self._my_single_node_task.execute(self._context, self._task_input)
+            assert _common_constants.OUTPUT_FILE_NAME in ret.keys()
 
 
 class DistributedCustomTrainingJobTaskTests(unittest.TestCase):


### PR DESCRIPTION
Fix the output-persisting logic for CustomTrainingJob that falsely blocked the output of a non-distributed training job

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Was missing the non-distributed training case. This PR adds that and make non-distributed training jobs always persist the output

## Tracking Issue

## Follow-up issue
