### PR TITLE
Switching from using model Metadata -> TaskMetadata

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -1,6 +1,6 @@
 import flytekit.plugins  # noqa: F401
 from flytekit.annotated.base_sql_task import SQLTask
-from flytekit.annotated.base_task import kwtypes
+from flytekit.annotated.base_task import TaskMetadata, kwtypes
 from flytekit.annotated.container_task import ContainerTask
 from flytekit.annotated.context_manager import FlyteContext
 from flytekit.annotated.dynamic_workflow_task import dynamic
@@ -9,7 +9,7 @@ from flytekit.annotated.map_task import maptask
 from flytekit.annotated.reference import get_reference_entity
 from flytekit.annotated.reference_entity import TaskReference, WorkflowReference
 from flytekit.annotated.reference_task import reference_task
-from flytekit.annotated.task import metadata, task
+from flytekit.annotated.task import task
 from flytekit.annotated.workflow import workflow
 from flytekit.loggers import logger
 

--- a/flytekit/annotated/base_sql_task.py
+++ b/flytekit/annotated/base_sql_task.py
@@ -1,9 +1,8 @@
 import re
-from typing import Any, Dict, Type, TypeVar
+from typing import Any, Dict, Optional, Type, TypeVar
 
-from flytekit.annotated.base_task import PythonTask
+from flytekit.annotated.base_task import PythonTask, TaskMetadata
 from flytekit.annotated.interface import Interface
-from flytekit.models import task as _task_model
 
 T = TypeVar("T")
 
@@ -18,19 +17,19 @@ class SQLTask(PythonTask[T]):
     def __init__(
         self,
         name: str,
-        metadata: _task_model.TaskMetadata,
         query_template: str,
-        inputs: Dict[str, Type],
+        task_type="sql_task",
+        inputs: Optional[Dict[str, Type]] = None,
+        metadata: Optional[TaskMetadata] = None,
         task_config: T = None,
         outputs: Dict[str, Type] = None,
-        task_type="sql_task",
         *args,
         **kwargs,
     ):
         super().__init__(
             task_type=task_type,
             name=name,
-            interface=Interface(inputs=inputs, outputs=outputs or {}),
+            interface=Interface(inputs=inputs or {}, outputs=outputs or {}),
             metadata=metadata,
             task_config=task_config,
             *args,

--- a/flytekit/annotated/base_task.py
+++ b/flytekit/annotated/base_task.py
@@ -1,5 +1,7 @@
 import collections
+import datetime
 from abc import abstractmethod
+from dataclasses import dataclass
 from typing import Any, Dict, Generic, Optional, Tuple, Type, TypeVar, Union
 
 from flytekit.annotated.context_manager import (
@@ -33,6 +35,57 @@ def kwtypes(**kwargs) -> Dict[str, Type]:
     return d
 
 
+@dataclass
+class TaskMetadata(object):
+    """
+    Create Metadata to be associated with this Task
+
+    Args:
+      cache: Boolean that indicates if caching should be enabled
+      cache_version: Version string to be used for the cached value
+      interruptible: Boolean that indicates that this task is of for interruptions and can be scheduled on nodes
+                           with lower QoS guarantees. This will directly reduce the `$`/`execution cost` associated,
+                            at the cost of performance penalties due to potential interruptions
+      deprecated: This should be used to indicate that the task is deprecated
+      retries: for retries=n; n > 0, on failures of this task, the task will be retried at-least n number of times.
+      timeout: the max amount of time for which one execution of this task should be executed for. If the execution
+                     will be terminated if the runtime exceeds the given timeout (approximately)
+     """
+
+    cache: bool = False
+    cache_version: str = ""
+    interruptible: bool = False
+    deprecated: str = ""
+    retries: int = 0
+    timeout: Optional[Union[datetime.timedelta, int]] = None
+
+    def __post_init__(self):
+        if self.timeout:
+            if isinstance(self.timeout, int):
+                self.timeout = datetime.timedelta(seconds=self.timeout)
+            elif not isinstance(self.timeout, datetime.timedelta):
+                raise ValueError("timeout should be duration represented as either a datetime.timedelta or int seconds")
+
+    @property
+    def retry_strategy(self) -> _literal_models.RetryStrategy:
+        return _literal_models.RetryStrategy(self.retries)
+
+    def to_taskmetadata_model(self) -> _task_model.TaskMetadata:
+        """
+        Converts to _task_model.TaskMetadata
+        """
+        return _task_model.TaskMetadata(
+            discoverable=self.cache,
+            # TODO Fix the version circular dependency before beta
+            runtime=_task_model.RuntimeMetadata(_task_model.RuntimeMetadata.RuntimeType.FLYTE_SDK, "0.16.0", "python"),
+            timeout=self.timeout,
+            retries=self.retry_strategy,
+            interruptible=self.interruptible,
+            discovery_version=self.cache_version,
+            deprecated_error_message=self.deprecated,
+        )
+
+
 # This is the least abstract task. It will have access to the loaded Python function
 # itself if run locally, so it will always be a Python task.
 # This is analogous to the current SdkRunnableTask. Need to analyze the benefits of duplicating the class versus
@@ -48,15 +101,15 @@ class Task(object):
         self,
         task_type: str,
         name: str,
-        interface: _interface_models.TypedInterface,
-        metadata: _task_model.TaskMetadata,
+        interface: Optional[_interface_models.TypedInterface] = None,
+        metadata: Optional[TaskMetadata] = None,
         *args,
         **kwargs,
     ):
         self._task_type = task_type
         self._name = name
         self._interface = interface
-        self._metadata = metadata
+        self._metadata = metadata if metadata else TaskMetadata()
 
         # This will get populated only at registration time, when we retrieve the rest of the environment variables like
         # project/domain/version/image and anything else we might need from the environment in the future.
@@ -69,7 +122,7 @@ class Task(object):
         return self._interface
 
     @property
-    def metadata(self) -> _task_model.TaskMetadata:
+    def metadata(self) -> TaskMetadata:
         return self._metadata
 
     @property
@@ -175,7 +228,7 @@ class Task(object):
         settings = FlyteContext.current_context().registration_settings
         tk = SdkTask(
             type=self.task_type,
-            metadata=self.metadata,
+            metadata=self.metadata.to_taskmetadata_model(),
             interface=self.interface,
             custom=self.get_custom(settings),
             container=self.get_container(settings),
@@ -233,9 +286,9 @@ class PythonTask(Task, Generic[T]):
         self,
         task_type: str,
         name: str,
-        interface: Interface,
-        metadata: _task_model.TaskMetadata,
         task_config: T,
+        interface: Optional[Interface] = None,
+        metadata: Optional[TaskMetadata] = None,
         *args,
         **kwargs,
     ):
@@ -268,7 +321,7 @@ class PythonTask(Task, Generic[T]):
             entity=self,
             interface=self.python_interface,
             timeout=self.metadata.timeout,
-            retry_strategy=self.metadata.retries,
+            retry_strategy=self.metadata.retry_strategy,
             **kwargs,
         )
 
@@ -289,7 +342,9 @@ class PythonTask(Task, Generic[T]):
 
         # Create another execution context with the new user params, but let's keep the same working dir
         with ctx.new_execution_context(
-            mode=ctx.execution_state.mode, execution_params=new_user_params, working_dir=ctx.execution_state.working_dir
+            mode=ctx.execution_state.mode,
+            execution_params=new_user_params,
+            working_dir=ctx.execution_state.working_dir,
         ) as exec_ctx:
             # TODO We could support default values here too - but not part of the plan right now
             # Translate the input literals to Python native

--- a/flytekit/annotated/container_task.py
+++ b/flytekit/annotated/container_task.py
@@ -1,7 +1,7 @@
 from enum import Enum
-from typing import Any, Dict, List, Type
+from typing import Any, Dict, List, Optional, Type
 
-from flytekit.annotated.base_task import PythonTask
+from flytekit.annotated.base_task import PythonTask, TaskMetadata
 from flytekit.annotated.context_manager import RegistrationSettings
 from flytekit.annotated.interface import Interface
 from flytekit.common.tasks.raw_container import _get_container_definition
@@ -26,9 +26,9 @@ class ContainerTask(PythonTask):
         self,
         name: str,
         image: str,
-        metadata: _task_model.TaskMetadata,
-        inputs: Dict[str, Type],
         command: List[str],
+        inputs: Optional[Dict[str, Type]] = None,
+        metadata: Optional[TaskMetadata] = None,
         arguments: List[str] = None,
         outputs: Dict[str, Type] = None,
         input_data_dir: str = None,

--- a/flytekit/annotated/dynamic_workflow_task.py
+++ b/flytekit/annotated/dynamic_workflow_task.py
@@ -1,6 +1,7 @@
 import functools
-from typing import Any, Callable, Union
+from typing import Any, Callable, Optional, Union
 
+from flytekit import TaskMetadata
 from flytekit.annotated import task
 from flytekit.annotated.context_manager import ExecutionState, FlyteContext
 from flytekit.annotated.python_function_task import PythonFunctionTask
@@ -9,7 +10,6 @@ from flytekit.annotated.workflow import Workflow
 from flytekit.loggers import logger
 from flytekit.models import dynamic_job as _dynamic_job
 from flytekit.models import literals as _literal_models
-from flytekit.models import task as _task_model
 
 
 class _Dynamic(object):
@@ -21,7 +21,7 @@ class DynamicWorkflowTask(PythonFunctionTask[_Dynamic]):
         self,
         task_config: _Dynamic,
         dynamic_workflow_function: Callable,
-        metadata: _task_model.TaskMetadata,
+        metadata: Optional[TaskMetadata] = None,
         *args,
         **kwargs,
     ):

--- a/flytekit/annotated/interface.py
+++ b/flytekit/annotated/interface.py
@@ -118,7 +118,9 @@ def transform_inputs_to_parameters(
     return _interface_models.ParameterMap(params)
 
 
-def transform_interface_to_typed_interface(interface: Interface) -> _interface_models.TypedInterface:
+def transform_interface_to_typed_interface(
+    interface: typing.Optional[Interface],
+) -> typing.Optional[_interface_models.TypedInterface]:
     """
     Transform the given simple python native interface to FlyteIDL's interface
     """

--- a/flytekit/annotated/map_task.py
+++ b/flytekit/annotated/map_task.py
@@ -1,8 +1,7 @@
-from typing import Any
+from typing import Any, Optional
 
-from flytekit.annotated.base_task import PythonTask
+from flytekit.annotated.base_task import PythonTask, TaskMetadata
 from flytekit.annotated.interface import transform_interface_to_list_interface
-from flytekit.models import task as _task_model
 
 
 class MapPythonTask(PythonTask):
@@ -14,7 +13,7 @@ class MapPythonTask(PythonTask):
     To do this we might have to give up on supporting lambda functions initially
     """
 
-    def __init__(self, tk: PythonTask, metadata: _task_model.TaskMetadata, *args, **kwargs):
+    def __init__(self, tk: PythonTask, metadata: Optional[TaskMetadata] = None, *args, **kwargs):
         collection_interface = transform_interface_to_list_interface(tk.python_interface)
         name = "mapper_" + tk.name
         self._run_task = tk

--- a/flytekit/annotated/node.py
+++ b/flytekit/annotated/node.py
@@ -116,6 +116,7 @@ class Node(object):
                 self._aliases.append(_workflow_model.Alias(var=k, alias=v))
 
 
+# TODO we should accept TaskMetadata here and then extract whatever fields we want into NodeMetadata
 def create_and_link_node(
     ctx: FlyteContext,
     entity,

--- a/flytekit/annotated/python_function_task.py
+++ b/flytekit/annotated/python_function_task.py
@@ -2,7 +2,7 @@ import inspect
 import re
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 
-from flytekit.annotated.base_task import PythonTask
+from flytekit.annotated.base_task import PythonTask, TaskMetadata
 from flytekit.annotated.context_manager import ImageConfig, RegistrationSettings
 from flytekit.annotated.interface import Interface, transform_signature_to_interface
 from flytekit.annotated.resources import Resources, ResourceSpec
@@ -61,9 +61,9 @@ class PythonFunctionTask(PythonTask[T]):
         self,
         task_config: T,
         task_function: Callable,
-        metadata: _task_model.TaskMetadata,
-        ignore_input_vars: List[str] = None,
         task_type="python-task",
+        metadata: Optional[TaskMetadata] = None,
+        ignore_input_vars: List[str] = None,
         container_image: str = None,
         requests: Resources = None,
         limits: Resources = None,

--- a/flytekit/annotated/reference_task.py
+++ b/flytekit/annotated/reference_task.py
@@ -1,10 +1,10 @@
 import inspect
 from typing import Callable, Dict, Optional, Type, Union
 
+from flytekit import TaskMetadata
 from flytekit.annotated.interface import transform_signature_to_interface
 from flytekit.annotated.python_function_task import PythonFunctionTask
 from flytekit.annotated.reference_entity import ReferenceEntity, TaskReference
-from flytekit.annotated.task import metadata as get_empty_metadata
 from flytekit.common.tasks.task import SdkTask
 
 
@@ -25,7 +25,11 @@ class ReferenceTask(ReferenceEntity, PythonFunctionTask):
         # settings = FlyteContext.current_context().registration_settings
         # This is a dummy sdk task, hopefully when we clean up
         tk = SdkTask(
-            type="ignore", metadata=get_empty_metadata(), interface=self.typed_interface, custom={}, container=None,
+            type="ignore",
+            metadata=TaskMetadata().to_taskmetadata_model(),
+            interface=self.typed_interface,
+            custom={},
+            container=None,
         )
         # Reset id to ensure it matches user input
         tk._id = self.id

--- a/flytekit/annotated/task.py
+++ b/flytekit/annotated/task.py
@@ -55,7 +55,7 @@ def task(
     cache: bool = False,
     cache_version: str = "",
     retries: int = 0,
-    interruptible: bool = False,
+    interruptable: bool = False,
     deprecated: str = "",
     timeout: Union[_datetime.timedelta, int] = 0,
     container_image: Optional[str] = None,
@@ -83,10 +83,11 @@ def task(
     :param cache: Boolean that indicates if caching should be enabled
     :param cache_version: Version string to be used for the cached value
     :param retries: for retries=n; n > 0, on failures of this task, the task will be retried at-least n number of times.
-    :param interruptible: Boolean that indicates that this task is of for interruptions and can be scheduled on nodes
+    :param interruptable: Boolean that indicates that this task can be interrupted and/or scheduled on nodes
                           with lower QoS guarantees. This will directly reduce the `$`/`execution cost` associated,
                            at the cost of performance penalties due to potential interruptions
-    :param deprecated: This should be used to indicate that the task is deprecated
+    :param deprecated: A string that can be used to provide a warning message for deprecated task. Absence / empty str
+                       indicates that the task is active and not deprecated
     :param timeout: the max amount of time for which one execution of this task should be executed for. If the execution
                     will be terminated if the runtime exceeds the given timeout (approximately)
     :param container_image: By default the configured FLYTE_INTERNAL_IMAGE is used for every task. This directive can be
@@ -118,7 +119,7 @@ def task(
             cache=cache,
             cache_version=cache_version,
             retries=retries,
-            interruptible=interruptible,
+            interruptable=interruptable,
             deprecated=deprecated,
             timeout=timeout,
         )

--- a/flytekit/taskplugins/pytorch/task.py
+++ b/flytekit/taskplugins/pytorch/task.py
@@ -3,10 +3,11 @@ This Plugin adds the capability of running distributed pytorch training to Flyte
 Kubernetes. It leverages `Pytorch Job <https://github.com/kubeflow/pytorch-operator>`_ Plugin from kubeflow.
 """
 from dataclasses import dataclass
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Optional
 
 from google.protobuf.json_format import MessageToDict
 
+from flytekit import TaskMetadata
 from flytekit.annotated.context_manager import RegistrationSettings
 from flytekit.annotated.python_function_task import PythonFunctionTask
 from flytekit.annotated.resources import Resources
@@ -45,12 +46,12 @@ class PyTorchFunctionTask(PythonFunctionTask[PyTorch]):
     _PYTORCH_TASK_TYPE = "pytorch"
 
     def __init__(
-        self, task_config: PyTorch, task_function: Callable, metadata: _task_model.TaskMetadata, *args, **kwargs
+        self, task_config: PyTorch, task_function: Callable, *args, metadata: Optional[TaskMetadata] = None, **kwargs
     ):
         super().__init__(
             task_config,
             task_function,
-            metadata,
+            metadata=metadata,
             task_type=self._PYTORCH_TASK_TYPE,
             requests=task_config.per_replica_requests,
             limits=task_config.per_replica_limits,

--- a/flytekit/taskplugins/sagemaker/hpo.py
+++ b/flytekit/taskplugins/sagemaker/hpo.py
@@ -1,18 +1,17 @@
 import json
 from dataclasses import dataclass
-from typing import Any, Dict, List, Type, Union
+from typing import Any, Dict, List, Optional, Type, Union
 
 from flyteidl.plugins.sagemaker import hyperparameter_tuning_job_pb2 as _pb2_hpo_job
 from flyteidl.plugins.sagemaker import parameter_ranges_pb2 as _pb2_params
 from google.protobuf import json_format
 from google.protobuf.json_format import MessageToDict
 
-from flytekit import FlyteContext
+from flytekit import FlyteContext, TaskMetadata
 from flytekit.annotated.base_task import PythonTask
 from flytekit.annotated.context_manager import RegistrationSettings
 from flytekit.annotated.type_engine import DictTransformer, TypeEngine, TypeTransformer
 from flytekit.common.types import primitives
-from flytekit.models import task as _task_model
 from flytekit.models.literals import Literal
 from flytekit.models.sagemaker import hpo_job as _hpo_job_model
 from flytekit.models.sagemaker import parameter_ranges as _params
@@ -46,10 +45,10 @@ class SagemakerHPOTask(PythonTask[HPOJob]):
     def __init__(
         self,
         name: str,
-        metadata: _task_model.TaskMetadata,
         task_config: HPOJob,
         training_task: Union[SagemakerCustomTrainingTask, SagemakerBuiltinAlgorithmsTask],
         *args,
+        metadata: Optional[TaskMetadata] = None,
         **kwargs
     ):
         if training_task is None or not (

--- a/flytekit/taskplugins/sagemaker/training.py
+++ b/flytekit/taskplugins/sagemaker/training.py
@@ -6,13 +6,12 @@ from typing import Any, Callable, Dict, TypeVar
 from google.protobuf.json_format import MessageToDict
 
 import flytekit
-from flytekit.annotated.base_task import PythonTask, kwtypes
+from flytekit.annotated.base_task import PythonTask, TaskMetadata, kwtypes
 from flytekit.annotated.context_manager import RegistrationSettings
 from flytekit.annotated.interface import Interface
 from flytekit.annotated.python_function_task import PythonFunctionTask
 from flytekit.annotated.task import TaskPlugins
 from flytekit.common.tasks.sdk_runnable import ExecutionParameters
-from flytekit.models import task as _task_model
 from flytekit.models.sagemaker import training_job as _training_job_models
 from flytekit.taskplugins.sagemaker.distributed_training import DistributedTrainingContext
 from flytekit.types import FlyteFile
@@ -54,7 +53,11 @@ class SagemakerBuiltinAlgorithmsTask(PythonTask[SagemakerTrainingJobConfig]):
     OUTPUT_TYPE = TypeVar("tar.gz")
 
     def __init__(
-        self, name: str, metadata: _task_model.TaskMetadata, task_config: SagemakerTrainingJobConfig, *args, **kwargs
+        self,
+        name: str,
+        task_config: SagemakerTrainingJobConfig,
+        metadata: typing.Optional[TaskMetadata] = None,
+        **kwargs,
     ):
         """
         Args:
@@ -80,7 +83,12 @@ class SagemakerBuiltinAlgorithmsTask(PythonTask[SagemakerTrainingJobConfig]):
             outputs=kwtypes(model=FlyteFile[self.OUTPUT_TYPE]),
         )
         super().__init__(
-            self._SAGEMAKER_TRAINING_JOB_TASK, name, interface, metadata, task_config=task_config, *args, **kwargs
+            self._SAGEMAKER_TRAINING_JOB_TASK,
+            name,
+            interface=interface,
+            metadata=metadata,
+            task_config=task_config,
+            **kwargs,
         )
 
     def get_custom(self, settings: RegistrationSettings) -> Dict[str, Any]:
@@ -118,12 +126,17 @@ class SagemakerCustomTrainingTask(PythonFunctionTask[SagemakerTrainingJobConfig]
         self,
         task_config: SagemakerTrainingJobConfig,
         task_function: Callable,
-        metadata: _task_model.TaskMetadata,
+        metadata: typing.Optional[TaskMetadata] = None,
         *args,
         **kwargs,
     ):
         super().__init__(
-            task_config, task_function, metadata, task_type=self._SAGEMAKER_CUSTOM_TRAINING_JOB_TASK, *args, **kwargs
+            task_config,
+            task_function,
+            metadata=metadata,
+            task_type=self._SAGEMAKER_CUSTOM_TRAINING_JOB_TASK,
+            *args,
+            **kwargs,
         )
 
     def get_custom(self, settings: RegistrationSettings) -> Dict[str, Any]:

--- a/flytekit/taskplugins/sidecar/task.py
+++ b/flytekit/taskplugins/sidecar/task.py
@@ -1,14 +1,14 @@
-from typing import Any, Callable, Dict, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 from flyteidl.core import tasks_pb2 as _core_task
 from google.protobuf.json_format import MessageToDict
 
+from flytekit import TaskMetadata
 from flytekit.annotated.context_manager import FlyteContext, RegistrationSettings
 from flytekit.annotated.promise import Promise
 from flytekit.annotated.python_function_task import PythonFunctionTask
 from flytekit.annotated.task import TaskPlugins
 from flytekit.common.exceptions import user as _user_exceptions
-from flytekit.models import task as _task_model
 from flytekit.models import task as _task_models
 from flytekit.plugins import k8s as _lazy_k8s
 
@@ -34,7 +34,7 @@ class Sidecar(object):
 
 class SidecarFunctionTask(PythonFunctionTask[Sidecar]):
     def __init__(
-        self, task_config: Sidecar, task_function: Callable, metadata: _task_model.TaskMetadata, *args, **kwargs
+        self, task_config: Sidecar, task_function: Callable, metadata: Optional[TaskMetadata] = None, *args, **kwargs
     ):
         super(SidecarFunctionTask, self).__init__(
             task_config=task_config,

--- a/flytekit/taskplugins/spark/task.py
+++ b/flytekit/taskplugins/spark/task.py
@@ -2,10 +2,11 @@ import os
 import sys
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Optional
 
 from google.protobuf.json_format import MessageToDict
 
+from flytekit import TaskMetadata
 from flytekit.annotated.context_manager import RegistrationSettings
 from flytekit.annotated.python_function_task import PythonFunctionTask
 from flytekit.annotated.task import TaskPlugins
@@ -44,11 +45,18 @@ class PysparkFunctionTask(PythonFunctionTask[Spark]):
     Actual Plugin that transforms the local python code for execution within a spark context
     """
 
+    _SPARK_TASK_TYPE = "spark"
+
     def __init__(
-        self, task_config: Spark, task_function: Callable, metadata: _task_model.TaskMetadata, *args, **kwargs
+        self, task_config: Spark, task_function: Callable, metadata: Optional[TaskMetadata] = None, *args, **kwargs
     ):
         super(PysparkFunctionTask, self).__init__(
-            task_config=task_config, task_type="spark", task_function=task_function, metadata=metadata, *args, **kwargs,
+            task_config=task_config,
+            task_type=self._SPARK_TASK_TYPE,
+            task_function=task_function,
+            metadata=metadata,
+            *args,
+            **kwargs,
         )
 
     def get_custom(self, settings: RegistrationSettings) -> Dict[str, Any]:

--- a/flytekit/taskplugins/sqlite/task.py
+++ b/flytekit/taskplugins/sqlite/task.py
@@ -6,10 +6,8 @@ import typing
 from dataclasses import dataclass
 from enum import Enum
 
-from flytekit import FlyteContext, kwtypes
-from flytekit import metadata as md
+from flytekit import FlyteContext, TaskMetadata, kwtypes
 from flytekit.annotated.base_sql_task import SQLTask
-from flytekit.models import task as _task_models
 from flytekit.plugins import pandas as pd
 from flytekit.types import FlyteFile, FlyteSchema
 from flytekit.types.flyte_file import unarchive_file
@@ -57,13 +55,14 @@ class SQLite3Task(SQLTask[SQLite3Config]):
           referenced task type?
     """
 
+    _SQLITE_TASK_TYPE = "sqlite"
     _SQLITE_INPUT_FILE = "sqlite"
 
     def __init__(
         self,
         name: str,
         query_template: str,
-        metadata: typing.Optional[_task_models.TaskMetadata] = None,
+        metadata: typing.Optional[TaskMetadata] = None,
         inputs: typing.Optional[typing.Dict[str, typing.Type]] = None,
         task_config: typing.Optional[SQLite3Config] = None,
         output_schema_type: typing.Optional[typing.Type[FlyteSchema]] = None,
@@ -82,10 +81,16 @@ class SQLite3Task(SQLTask[SQLite3Config]):
         if output_schema_type is None:
             output_schema_type = FlyteSchema
         outputs = kwtypes(results=output_schema_type)
-        if metadata is None:
-            metadata = md()
         super().__init__(
-            name, metadata, query_template, inputs, outputs=outputs, task_config=task_config, *args, **kwargs
+            task_type=self._SQLITE_TASK_TYPE,
+            name=name,
+            query_template=query_template,
+            inputs=inputs,
+            metadata=metadata,
+            outputs=outputs,
+            task_config=task_config,
+            *args,
+            **kwargs,
         )
 
     def execute(self, **kwargs) -> typing.Any:

--- a/flytekit/taskplugins/tensorflow/task.py
+++ b/flytekit/taskplugins/tensorflow/task.py
@@ -3,10 +3,11 @@ This Plugin adds the capability of running distributed tensorflow training to Fl
 Kubernetes. It leverages `TF Job <https://github.com/kubeflow/tf-operator>`_ Plugin from kubeflow.
 """
 from dataclasses import dataclass
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Optional
 
 from google.protobuf.json_format import MessageToDict
 
+from flytekit import TaskMetadata
 from flytekit.annotated.context_manager import RegistrationSettings
 from flytekit.annotated.python_function_task import PythonFunctionTask
 from flytekit.annotated.resources import Resources
@@ -48,16 +49,18 @@ class TensorflowFunctionTask(PythonFunctionTask[TfJob]):
         defined by the code within the _task_function to k8s cluster.
     """
 
+    _TF_JOB_TASK_TYPE = "tensorflow"
+
     def __init__(
-        self, task_config: TfJob, task_function: Callable, metadata: _task_model.TaskMetadata, *args, **kwargs
+        self, task_config: TfJob, task_function: Callable, metadata: Optional[TaskMetadata] = None, *args, **kwargs
     ):
         super().__init__(
-            task_config,
-            task_function,
-            metadata,
+            task_type=self._TF_JOB_TASK_TYPE,
+            task_config=task_config,
+            task_function=task_function,
+            metadata=metadata,
             requests=task_config.per_replica_requests,
             limits=task_config.per_replica_limits,
-            task_type="tensorflow",
             *args,
             **kwargs
         )

--- a/tests/flytekit/unit/annotated/test_serialization.py
+++ b/tests/flytekit/unit/annotated/test_serialization.py
@@ -5,7 +5,7 @@ from flytekit import ContainerTask, kwtypes
 from flytekit.annotated import context_manager
 from flytekit.annotated.condition import conditional
 from flytekit.annotated.context_manager import FlyteContext, Image, ImageConfig, get_image_config
-from flytekit.annotated.task import metadata, task
+from flytekit.annotated.task import task
 from flytekit.annotated.workflow import workflow
 from flytekit.configuration import set_flyte_config_file
 
@@ -13,7 +13,6 @@ from flytekit.configuration import set_flyte_config_file
 def test_serialization():
     square = ContainerTask(
         name="square",
-        metadata=metadata(),
         input_data_dir="/var/inputs",
         output_data_dir="/var/outputs",
         inputs=kwtypes(val=int),
@@ -24,7 +23,6 @@ def test_serialization():
 
     sum = ContainerTask(
         name="sum",
-        metadata=metadata(),
         input_data_dir="/var/flyte/inputs",
         output_data_dir="/var/flyte/outputs",
         inputs=kwtypes(x=int, y=int),

--- a/tests/flytekit/unit/annotated/test_type_hints.py
+++ b/tests/flytekit/unit/annotated/test_type_hints.py
@@ -14,7 +14,7 @@ from flytekit.annotated.condition import conditional
 from flytekit.annotated.context_manager import ExecutionState, Image, ImageConfig
 from flytekit.annotated.promise import Promise
 from flytekit.annotated.resources import Resources
-from flytekit.annotated.task import metadata, task
+from flytekit.annotated.task import TaskMetadata, task
 from flytekit.annotated.testing import patch, task_mock
 from flytekit.annotated.type_engine import RestrictedTypeError, TypeEngine
 from flytekit.annotated.workflow import workflow
@@ -269,7 +269,7 @@ def test_wf1_with_sql():
         query_template="SELECT * FROM hive.city.fact_airport_sessions WHERE ds = '{{ .Inputs.ds }}' LIMIT 10",
         inputs=kwtypes(ds=datetime.datetime),
         outputs=kwtypes(results=FlyteSchema),
-        metadata=metadata(retries=2),
+        metadata=TaskMetadata(retries=2),
     )
 
     @task
@@ -292,7 +292,7 @@ def test_wf1_with_sql_with_patch():
         query_template="SELECT * FROM hive.city.fact_airport_sessions WHERE ds = '{{ .Inputs.ds }}' LIMIT 10",
         inputs=kwtypes(ds=datetime.datetime),
         outputs=kwtypes(results=FlyteSchema),
-        metadata=metadata(retries=2),
+        metadata=TaskMetadata(retries=2),
     )
 
     @task
@@ -331,7 +331,7 @@ def test_wf1_with_map():
 
     @workflow
     def my_wf(a: typing.List[int]) -> (int, str):
-        x, y = maptask(t1, metadata=metadata(retries=1))(a=a)
+        x, y = maptask(t1, metadata=TaskMetadata(retries=1))(a=a)
         return t2(a=x, b=y)
 
     x = my_wf(a=[5, 6])
@@ -447,7 +447,7 @@ def test_list_output():
 
 def test_comparison_refs():
     def dummy_node(id) -> SdkNode:
-        n = SdkNode(id, [], None, None, sdk_task=SQLTask(name="x", query_template="x", inputs={}, metadata=metadata()))
+        n = SdkNode(id, [], None, None, sdk_task=SQLTask(name="x", query_template="x", inputs={}))
         n._id = id
         return n
 
@@ -745,7 +745,6 @@ def test_wf_container_task():
         output_data_dir="/tmp",
         command=["cat"],
         arguments=["/tmp/a"],
-        metadata=metadata(),
     )
 
     def wf(a: int):
@@ -762,7 +761,6 @@ def test_wf_container_task():
 def test_wf_container_task_multiple():
     square = ContainerTask(
         name="square",
-        metadata=metadata(),
         input_data_dir="/var/inputs",
         output_data_dir="/var/outputs",
         inputs=kwtypes(val=int),
@@ -773,7 +771,6 @@ def test_wf_container_task_multiple():
 
     sum = ContainerTask(
         name="sum",
-        metadata=metadata(),
         input_data_dir="/var/flyte/inputs",
         output_data_dir="/var/flyte/outputs",
         inputs=kwtypes(x=int, y=int),

--- a/tests/flytekit/unit/taskplugins/pytorch/test_pytorch_task.py
+++ b/tests/flytekit/unit/taskplugins/pytorch/test_pytorch_task.py
@@ -5,7 +5,7 @@ from flytekit.taskplugins.pytorch.task import PyTorch
 
 
 def test_pytorch_task():
-    @task(task_config=PyTorch(num_workers=10, per_replica_requests=Resources(cpu="1")), cache=True)
+    @task(task_config=PyTorch(num_workers=10, per_replica_requests=Resources(cpu="1")), cache=True, cache_version="1")
     def my_pytorch_task(x: int, y: str) -> int:
         return x
 

--- a/tests/flytekit/unit/taskplugins/sagemaker/test_hpo.py
+++ b/tests/flytekit/unit/taskplugins/sagemaker/test_hpo.py
@@ -1,6 +1,6 @@
 import pytest
 
-from flytekit import FlyteContext, metadata
+from flytekit import FlyteContext
 from flytekit.common.types.primitives import Generic
 from flytekit.taskplugins.sagemaker import (
     AlgorithmName,
@@ -24,7 +24,6 @@ from tests.flytekit.unit.taskplugins.sagemaker.test_training import _get_reg_set
 def test_hpo_for_builtin():
     trainer = SagemakerBuiltinAlgorithmsTask(
         name="builtin-trainer",
-        metadata=metadata(),
         task_config=SagemakerTrainingJobConfig(
             training_job_resource_config=TrainingJobResourceConfig(
                 instance_count=1, instance_type="ml-xlarge", volume_size_in_gb=1,
@@ -33,7 +32,7 @@ def test_hpo_for_builtin():
         ),
     )
 
-    hpo = SagemakerHPOTask(name="test", metadata=metadata(), task_config=HPOJob(10, 10, ["x"]), training_task=trainer,)
+    hpo = SagemakerHPOTask(name="test", task_config=HPOJob(10, 10, ["x"]), training_task=trainer,)
 
     assert hpo.python_interface.inputs.keys() == {
         "static_hyperparameters",

--- a/tests/flytekit/unit/taskplugins/sagemaker/test_training.py
+++ b/tests/flytekit/unit/taskplugins/sagemaker/test_training.py
@@ -4,7 +4,7 @@ import tempfile
 import pytest
 
 import flytekit
-from flytekit import metadata, task
+from flytekit import task
 from flytekit.annotated.context_manager import Image, ImageConfig, RegistrationSettings
 from flytekit.common.tasks.sdk_runnable import ExecutionParameters
 from flytekit.taskplugins.sagemaker import (
@@ -33,7 +33,6 @@ def _get_reg_settings():
 def test_builtin_training():
     trainer = SagemakerBuiltinAlgorithmsTask(
         name="builtin-trainer",
-        metadata=metadata(),
         task_config=SagemakerTrainingJobConfig(
             training_job_resource_config=TrainingJobResourceConfig(
                 instance_count=1, instance_type="ml-xlarge", volume_size_in_gb=1,

--- a/tests/flytekit/unit/taskplugins/sqlite/test_task.py
+++ b/tests/flytekit/unit/taskplugins/sqlite/test_task.py
@@ -3,6 +3,7 @@ import pytest
 from flytekit import kwtypes, task, workflow
 from flytekit.plugins import pandas
 from flytekit.taskplugins.sqlite.task import SQLite3Config, SQLite3Task
+
 # https://www.sqlitetutorial.net/sqlite-sample-database/
 from flytekit.types import FlyteFile
 

--- a/tests/flytekit/unit/taskplugins/tensorflow/test_tensorflow_task.py
+++ b/tests/flytekit/unit/taskplugins/tensorflow/test_tensorflow_task.py
@@ -9,7 +9,7 @@ def test_tensorflow_task():
         task_config=TfJob(
             num_workers=10, per_replica_requests=Resources(cpu="1"), num_ps_replicas=1, num_chief_replicas=1
         ),
-        cache=True,
+        cache=True, cache_version="1",
     )
     def my_tensorflow_task(x: int, y: str) -> int:
         return x


### PR DESCRIPTION
TaskMetadata will be maintained as a shadow and allows decoupling of
protocol buffer types from contributor code and user code. This allows
more flexiblity

another prime motivation behind this change is that - it allows making the interface less verbose. This makes it trivial to support default values for metadata.

