### PR TITLE
Annotations o0 n0

### DIFF
--- a/flytekit/annotated/condition.py
+++ b/flytekit/annotated/condition.py
@@ -277,7 +277,7 @@ def create_branch_node_promise_var(node_id: str, var: str) -> str:
 
     When building bindings for the branch node, the inputs to the conditions (e.g. (x==5)) need to have variable names
     (e.g. x). Because it's currently infeasible to get the name (e.g. x), we resolve to using the referenced node's
-    output name (e.g. out_0, my_out,... etc.). In order to avoid naming collisions (in cases when, for example, the
+    output name (e.g. o0, my_out,... etc.). In order to avoid naming collisions (in cases when, for example, the
     conditions reference two outputs of two different nodes named the same), we build a variable name composed of the
     referenced node name + '.' + the referenced output name. Ideally we use something like
     (https://github.com/pwwang/python-varname) to retrieve the assigned variable name (e.g. x). However, because of

--- a/flytekit/annotated/context_manager.py
+++ b/flytekit/annotated/context_manager.py
@@ -153,7 +153,7 @@ class CompilationState(object):
     def __init__(self, prefix: str):
         """
         :param prefix: This is because we may one day want to be able to have subworkflows inside other workflows. If
-          users choose to not specify their node names, then we can end up with multiple "node-0"s. This prefix allows
+          users choose to not specify their node names, then we can end up with multiple "n0"s. This prefix allows
           us to give those nested nodes a distinct name, as well as properly identify them in the workflow.
           # TODO: Ketan to revisit this whole concept when we re-organize the new structure
         """

--- a/flytekit/annotated/interface.py
+++ b/flytekit/annotated/interface.py
@@ -268,7 +268,7 @@ def transform_type(x: type, description: str = None) -> _interface_models.Variab
 
 
 def default_output_name(index: int = 0) -> str:
-    return f"out_{index}"
+    return f"o{index}"
 
 
 def output_name_generator(length: int) -> Generator[str, None, None]:

--- a/flytekit/annotated/node.py
+++ b/flytekit/annotated/node.py
@@ -198,7 +198,7 @@ def create_and_link_node(
     # TODO: Clean up NodeOutput dependency on SdkNode, then rename variable
     non_sdk_node = Node(
         # TODO: Better naming, probably a derivative of the function name.
-        id=f"{ctx.compilation_state.prefix}node-{len(ctx.compilation_state.nodes)}",
+        id=f"{ctx.compilation_state.prefix}n{len(ctx.compilation_state.nodes)}",
         metadata=node_metadata,
         bindings=sorted(bindings, key=lambda b: b.var),
         upstream_nodes=upstream_nodes,  # type: ignore

--- a/flytekit/annotated/node_creation.py
+++ b/flytekit/annotated/node_creation.py
@@ -62,7 +62,7 @@ def create_node(
     needs to be dereferenced by the output name.
 
         t1_node = create_node(t1)
-        t2(t1_node.out_0)
+        t2(t1_node.o0)
 
     """
     if len(args) > 0:

--- a/tests/flytekit/unit/annotated/test_interface.py
+++ b/tests/flytekit/unit/annotated/test_interface.py
@@ -28,39 +28,39 @@ def test_extract_only():
 
     return_type = extract_return_annotation(inspect.signature(t).return_annotation)
     assert len(return_type) == 1
-    assert return_type["out_0"]._name == "List"
-    assert return_type["out_0"].__origin__ == list
+    assert return_type["o0"]._name == "List"
+    assert return_type["o0"].__origin__ == list
 
     def t() -> Dict[str, int]:
         ...
 
     return_type = extract_return_annotation(inspect.signature(t).return_annotation)
     assert len(return_type) == 1
-    assert return_type["out_0"]._name == "Dict"
-    assert return_type["out_0"].__origin__ == dict
+    assert return_type["o0"]._name == "Dict"
+    assert return_type["o0"].__origin__ == dict
 
     def t(a: int, b: str) -> typing.Tuple[int, str]:
         ...
 
     return_type = extract_return_annotation(inspect.signature(t).return_annotation)
     assert len(return_type) == 2
-    assert return_type["out_0"] == int
-    assert return_type["out_1"] == str
+    assert return_type["o0"] == int
+    assert return_type["o1"] == str
 
     def t(a: int, b: str) -> (int, str):
         ...
 
     return_type = extract_return_annotation(inspect.signature(t).return_annotation)
     assert len(return_type) == 2
-    assert return_type["out_0"] == int
-    assert return_type["out_1"] == str
+    assert return_type["o0"] == int
+    assert return_type["o1"] == str
 
     def t(a: int, b: str) -> str:
         ...
 
     return_type = extract_return_annotation(inspect.signature(t).return_annotation)
     assert len(return_type) == 1
-    assert return_type["out_0"] == str
+    assert return_type["o0"] == str
 
     def t(a: int, b: str) -> None:
         ...
@@ -73,14 +73,14 @@ def test_extract_only():
 
     return_type = extract_return_annotation(inspect.signature(t).return_annotation)
     assert len(return_type) == 1
-    assert return_type["out_0"] == List[int]
+    assert return_type["o0"] == List[int]
 
     def t(a: int, b: str) -> Dict[str, int]:
         ...
 
     return_type = extract_return_annotation(inspect.signature(t).return_annotation)
     assert len(return_type) == 1
-    assert return_type["out_0"] == Dict[str, int]
+    assert return_type["o0"] == Dict[str, int]
 
 
 def test_named_tuples():
@@ -106,8 +106,8 @@ def test_unnamed_typing_tuple():
         return 5, "hello world"
 
     result = transform_variable_map(extract_return_annotation(inspect.signature(z).return_annotation))
-    assert result["out_0"].type.simple == 1
-    assert result["out_1"].type.simple == 3
+    assert result["o0"].type.simple == 1
+    assert result["o1"].type.simple == 3
 
 
 def test_regular_tuple():
@@ -115,8 +115,8 @@ def test_regular_tuple():
         return 5, "hello world"
 
     result = transform_variable_map(extract_return_annotation(inspect.signature(q).return_annotation))
-    assert result["out_0"].type.simple == 1
-    assert result["out_1"].type.simple == 3
+    assert result["o0"].type.simple == 1
+    assert result["o1"].type.simple == 3
 
 
 def test_single_output_new_decorator():
@@ -124,7 +124,7 @@ def test_single_output_new_decorator():
         return a + len(b)
 
     result = transform_variable_map(extract_return_annotation(inspect.signature(q).return_annotation))
-    assert result["out_0"].type.simple == 1
+    assert result["o0"].type.simple == 1
 
 
 def test_sig_files():
@@ -132,7 +132,7 @@ def test_sig_files():
         ...
 
     result = transform_variable_map(extract_return_annotation(inspect.signature(q).return_annotation))
-    assert isinstance(result["out_0"].type.blob, _core_types.BlobType)
+    assert isinstance(result["o0"].type.blob, _core_types.BlobType)
 
 
 def test_file_types():
@@ -140,7 +140,7 @@ def test_file_types():
         ...
 
     return_type = extract_return_annotation(inspect.signature(t1).return_annotation)
-    assert return_type["out_0"].extension() == FlyteFile["svg"].extension()
+    assert return_type["o0"].extension() == FlyteFile["svg"].extension()
 
 
 def test_parameters_and_defaults():

--- a/tests/flytekit/unit/annotated/test_node_creation.py
+++ b/tests/flytekit/unit/annotated/test_node_creation.py
@@ -15,7 +15,7 @@ def test_normal_task():
     @workflow
     def my_wf(a: str) -> str:
         t1_node = create_node(t1, a=a)
-        return t1_node.out_0
+        return t1_node.o0
 
     r = my_wf(a="hello")
     assert r == "hello world"
@@ -66,12 +66,12 @@ def test_normal_task():
         )
     ):
         sdk_wf = empty_wf.get_registerable_entity()
-        assert sdk_wf.nodes[0].upstream_node_ids[0] == "node-1"
-        assert sdk_wf.nodes[0].id == "node-0"
+        assert sdk_wf.nodes[0].upstream_node_ids[0] == "n1"
+        assert sdk_wf.nodes[0].id == "n0"
 
         sdk_wf = empty_wf2.get_registerable_entity()
-        assert sdk_wf.nodes[0].upstream_node_ids[0] == "node-1"
-        assert sdk_wf.nodes[0].id == "node-0"
+        assert sdk_wf.nodes[0].upstream_node_ids[0] == "n1"
+        assert sdk_wf.nodes[0].id == "n0"
 
 
 def test_more_normal_task():
@@ -96,7 +96,7 @@ def test_more_normal_task():
         t1_node = create_node(t1, a=a)
         t1_nt_node = create_node(t1_nt, a=a)
         t2_node = create_node(t2, a=[t1_node.t1_str_output, t1_nt_node.t1_str_output, b])
-        return t1_node.t1_str_output, t2_node.out_0
+        return t1_node.t1_str_output, t2_node.o0
 
     x = my_wf(a=5, b="hello")
     assert x == ("7", "7 7 hello")

--- a/tests/flytekit/unit/annotated/test_references.py
+++ b/tests/flytekit/unit/annotated/test_references.py
@@ -42,7 +42,7 @@ def test_ref():
         ss = ref_t1.get_registerable_entity()
         assert ss.id == ref_t1.id
         assert ss.interface.inputs["a"] is not None
-        assert ss.interface.outputs["out_0"] is not None
+        assert ss.interface.outputs["o0"] is not None
 
     registration_settings = context_manager.RegistrationSettings(
         project="proj",
@@ -181,7 +181,7 @@ def test_ref_plain_two_outputs():
         assert xx.ref.sdk_node is yy.ref.sdk_node
         assert xx.var == "x"
         assert yy.var == "y"
-        assert xx.ref.node_id == "node-0"
+        assert xx.ref.node_id == "n0"
         assert len(xx.ref.sdk_node.bindings) == 2
 
     @task

--- a/tests/flytekit/unit/annotated/test_serialization.py
+++ b/tests/flytekit/unit/annotated/test_serialization.py
@@ -196,7 +196,7 @@ def test_serialization_branch_complex_2():
     with ctx.current_context().new_registration_settings(registration_settings=registration_settings):
         wf = my_wf.get_registerable_entity()
         assert wf is not None
-        assert wf.nodes[1].inputs[0].var == "node-0.t1_int_output"
+        assert wf.nodes[1].inputs[0].var == "n0.t1_int_output"
 
 
 def test_serialization_branch():

--- a/tests/flytekit/unit/annotated/test_type_hints.py
+++ b/tests/flytekit/unit/annotated/test_type_hints.py
@@ -115,11 +115,11 @@ def test_wf1():
         return x, d
 
     assert len(my_wf._nodes) == 2
-    assert my_wf._nodes[0].id == "node-0"
+    assert my_wf._nodes[0].id == "n0"
     assert my_wf._nodes[1]._upstream_nodes[0] is my_wf._nodes[0]
 
     assert len(my_wf._output_bindings) == 2
-    assert my_wf._output_bindings[0].var == "out_0"
+    assert my_wf._output_bindings[0].var == "o0"
     assert my_wf._output_bindings[0].binding.promise.var == "t1_int_output"
 
     nt = typing.NamedTuple("SingleNT", t1_int_output=float)

--- a/tests/flytekit/unit/taskplugins/hive/test_hive_task.py
+++ b/tests/flytekit/unit/taskplugins/hive/test_hive_task.py
@@ -50,9 +50,9 @@ def test_serialization():
         assert len(sdk_task.interface.outputs) == 1
 
         sdk_wf = my_wf.get_registerable_entity()
-        assert sdk_wf.interface.outputs["out_0"].type.schema is not None
-        assert sdk_wf.outputs[0].var == "out_0"
-        assert sdk_wf.outputs[0].binding.promise.node_id == "node-0"
+        assert sdk_wf.interface.outputs["o0"].type.schema is not None
+        assert sdk_wf.outputs[0].var == "o0"
+        assert sdk_wf.outputs[0].binding.promise.node_id == "n0"
         assert sdk_wf.outputs[0].binding.promise.var == "results"
 
 

--- a/tests/flytekit/unit/taskplugins/sagemaker/test_training.py
+++ b/tests/flytekit/unit/taskplugins/sagemaker/test_training.py
@@ -71,7 +71,7 @@ def test_custom_training():
         return x
 
     assert my_custom_trainer.python_interface.inputs == {"x": int}
-    assert my_custom_trainer.python_interface.outputs == {"out_0": int}
+    assert my_custom_trainer.python_interface.outputs == {"o0": int}
 
     assert my_custom_trainer(x=10) == 10
 
@@ -100,7 +100,7 @@ def test_distributed_custom_training():
         return x
 
     assert my_custom_trainer.python_interface.inputs == {"x": int}
-    assert my_custom_trainer.python_interface.outputs == {"out_0": int}
+    assert my_custom_trainer.python_interface.outputs == {"o0": int}
 
     assert my_custom_trainer(x=10) == 10
 


### PR DESCRIPTION
Make automatically generated output names `o0, o1, o2, ...` rather than `out_0, out_1, out_2, ...`.
Make automatically generated node names `n0, n1, n2, ...` rather than `node-0, node-1, node-2, ...`.
