### PR TITLE
Annotations - workflow metadata

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -10,7 +10,7 @@ from flytekit.annotated.reference import get_reference_entity
 from flytekit.annotated.reference_entity import TaskReference, WorkflowReference
 from flytekit.annotated.reference_task import reference_task
 from flytekit.annotated.task import task
-from flytekit.annotated.workflow import workflow
+from flytekit.annotated.workflow import WorkflowFailurePolicy, workflow
 from flytekit.loggers import logger
 
 __version__ = "0.16.0a2"

--- a/flytekit/annotated/dynamic_workflow_task.py
+++ b/flytekit/annotated/dynamic_workflow_task.py
@@ -6,7 +6,7 @@ from flytekit.annotated import task
 from flytekit.annotated.context_manager import ExecutionState, FlyteContext
 from flytekit.annotated.python_function_task import PythonFunctionTask
 from flytekit.annotated.task import TaskPlugins
-from flytekit.annotated.workflow import Workflow
+from flytekit.annotated.workflow import Workflow, WorkflowMetadata
 from flytekit.loggers import logger
 from flytekit.models import dynamic_job as _dynamic_job
 from flytekit.models import literals as _literal_models
@@ -36,7 +36,9 @@ class DynamicWorkflowTask(PythonFunctionTask[_Dynamic]):
         self, ctx: FlyteContext, **kwargs
     ) -> Union[_dynamic_job.DynamicJobSpec, _literal_models.LiteralMap]:
         with ctx.new_compilation_context(prefix="dynamic"):
-            self._wf = Workflow(self._task_function)
+            workflow_metadata = WorkflowMetadata(on_failure=WorkflowMetadata.OnFailurePolicy.FAIL_IMMEDIATELY)
+
+            self._wf = Workflow(self._task_function, metadata=workflow_metadata)
             self._wf.compile(**kwargs)
 
             wf = self._wf

--- a/flytekit/annotated/dynamic_workflow_task.py
+++ b/flytekit/annotated/dynamic_workflow_task.py
@@ -6,7 +6,7 @@ from flytekit.annotated import task
 from flytekit.annotated.context_manager import ExecutionState, FlyteContext
 from flytekit.annotated.python_function_task import PythonFunctionTask
 from flytekit.annotated.task import TaskPlugins
-from flytekit.annotated.workflow import Workflow, WorkflowMetadata
+from flytekit.annotated.workflow import Workflow, WorkflowMetadata, WorkflowMetadataDefaults
 from flytekit.loggers import logger
 from flytekit.models import dynamic_job as _dynamic_job
 from flytekit.models import literals as _literal_models
@@ -24,6 +24,8 @@ class DynamicWorkflowTask(PythonFunctionTask[_Dynamic]):
         metadata: Optional[TaskMetadata] = None,
         **kwargs,
     ):
+        self._wf = None
+
         super().__init__(
             task_config=task_config,
             task_function=dynamic_workflow_function,
@@ -37,8 +39,9 @@ class DynamicWorkflowTask(PythonFunctionTask[_Dynamic]):
     ) -> Union[_dynamic_job.DynamicJobSpec, _literal_models.LiteralMap]:
         with ctx.new_compilation_context(prefix="dynamic"):
             workflow_metadata = WorkflowMetadata(on_failure=WorkflowMetadata.OnFailurePolicy.FAIL_IMMEDIATELY)
+            defaults = WorkflowMetadataDefaults(interruptible=False)
 
-            self._wf = Workflow(self._task_function, metadata=workflow_metadata)
+            self._wf = Workflow(self._task_function, metadata=workflow_metadata, default_metadata=defaults)
             self._wf.compile(**kwargs)
 
             wf = self._wf

--- a/flytekit/annotated/dynamic_workflow_task.py
+++ b/flytekit/annotated/dynamic_workflow_task.py
@@ -6,7 +6,7 @@ from flytekit.annotated import task
 from flytekit.annotated.context_manager import ExecutionState, FlyteContext
 from flytekit.annotated.python_function_task import PythonFunctionTask
 from flytekit.annotated.task import TaskPlugins
-from flytekit.annotated.workflow import Workflow, WorkflowMetadata, WorkflowMetadataDefaults
+from flytekit.annotated.workflow import Workflow, WorkflowFailurePolicy, WorkflowMetadata, WorkflowMetadataDefaults
 from flytekit.loggers import logger
 from flytekit.models import dynamic_job as _dynamic_job
 from flytekit.models import literals as _literal_models
@@ -38,7 +38,7 @@ class DynamicWorkflowTask(PythonFunctionTask[_Dynamic]):
         self, ctx: FlyteContext, **kwargs
     ) -> Union[_dynamic_job.DynamicJobSpec, _literal_models.LiteralMap]:
         with ctx.new_compilation_context(prefix="dynamic"):
-            workflow_metadata = WorkflowMetadata(on_failure=WorkflowMetadata.OnFailurePolicy.FAIL_IMMEDIATELY)
+            workflow_metadata = WorkflowMetadata(on_failure=WorkflowFailurePolicy.FAIL_IMMEDIATELY)
             defaults = WorkflowMetadataDefaults(interruptible=False)
 
             self._wf = Workflow(self._task_function, metadata=workflow_metadata, default_metadata=defaults)

--- a/flytekit/annotated/workflow.py
+++ b/flytekit/annotated/workflow.py
@@ -372,10 +372,12 @@ class ReferenceWorkflow(ReferenceEntity, Workflow):
         if self._registerable_entity is not None:
             return self._registerable_entity
 
+        workflow_metadata = WorkflowMetadata(on_failure=WorkflowMetadata.OnFailurePolicy.FAIL_IMMEDIATELY)
+
         self._registerable_entity = _SdkWorkflow(
             nodes=[],  # Fake an empty list for nodes,
             id=self.reference.id,
-            metadata=self.workflow_metadata.to_flyte_model(),
+            metadata=workflow_metadata,
             metadata_defaults=_workflow_model.WorkflowMetadataDefaults(),
             interface=self.typed_interface,
             output_bindings=[],

--- a/flytekit/models/core/workflow.py
+++ b/flytekit/models/core/workflow.py
@@ -519,13 +519,17 @@ class WorkflowMetadataDefaults(_common.FlyteIdlEntity):
         """
         Metadata Defaults for the workflow.
         """
-        self.interruptible_ = interruptible
+        self._interruptible = interruptible
+
+    @property
+    def interruptible(self):
+        return self._interruptible
 
     def to_flyte_idl(self):
         """
         :rtype: flyteidl.core.workflow_pb2.WorkflowMetadataDefaults
         """
-        return _core_workflow.WorkflowMetadataDefaults(interruptible=self.interruptible_)
+        return _core_workflow.WorkflowMetadataDefaults(interruptible=self._interruptible)
 
     @classmethod
     def from_flyte_idl(cls, pb2_object):

--- a/tests/flytekit/unit/annotated/test_workflows.py
+++ b/tests/flytekit/unit/annotated/test_workflows.py
@@ -1,0 +1,54 @@
+import typing
+
+import pytest
+
+from flytekit.annotated import context_manager
+from flytekit.annotated.context_manager import Image, ImageConfig
+from flytekit.annotated.task import task
+from flytekit.annotated.workflow import WorkflowMetadata, WorkflowMetadataDefaults, workflow
+from flytekit.common.exceptions.user import FlyteValidationException
+
+
+def test_metadata_values():
+    with pytest.raises(FlyteValidationException):
+        WorkflowMetadata(on_failure=0)
+
+    wm = WorkflowMetadata(on_failure=WorkflowMetadata.OnFailurePolicy.FAIL_IMMEDIATELY)
+    assert wm.on_failure == WorkflowMetadata.OnFailurePolicy.FAIL_IMMEDIATELY
+
+
+def test_default_metadata_values():
+    with pytest.raises(FlyteValidationException):
+        WorkflowMetadataDefaults(3)
+
+    wm = WorkflowMetadataDefaults(interruptible=False)
+    assert wm.interruptible is False
+
+
+def test_workflow_values():
+    @task
+    def t1(a: int) -> typing.NamedTuple("OutputsBC", t1_int_output=int, c=str):
+        a = a + 2
+        return a, "world-" + str(a)
+
+    @workflow(interruptible=True, failure_policy=WorkflowMetadata.OnFailurePolicy.FAIL_AFTER_EXECUTABLE_NODES_COMPLETE)
+    def wf(a: int) -> (str, str):
+        x, y = t1(a=a)
+        u, v = t1(a=x)
+        return y, v
+
+    registration_settings = context_manager.RegistrationSettings(
+        project="proj",
+        domain="dom",
+        version="123",
+        image_config=ImageConfig(Image(name="name", fqn="asdf/fdsa", tag="123")),
+        env={},
+        iam_role="test:iam:role",
+        service_account=None,
+    )
+    with context_manager.FlyteContext.current_context().new_registration_settings(
+        registration_settings=registration_settings
+    ):
+        sdk_wf = wf.get_registerable_entity()
+        assert sdk_wf.metadata_defaults.interruptible
+        assert sdk_wf.metadata.on_failure == 1

--- a/tests/flytekit/unit/annotated/test_workflows.py
+++ b/tests/flytekit/unit/annotated/test_workflows.py
@@ -5,7 +5,7 @@ import pytest
 from flytekit.annotated import context_manager
 from flytekit.annotated.context_manager import Image, ImageConfig
 from flytekit.annotated.task import task
-from flytekit.annotated.workflow import WorkflowMetadata, WorkflowMetadataDefaults, workflow
+from flytekit.annotated.workflow import WorkflowFailurePolicy, WorkflowMetadata, WorkflowMetadataDefaults, workflow
 from flytekit.common.exceptions.user import FlyteValidationException
 
 
@@ -13,8 +13,8 @@ def test_metadata_values():
     with pytest.raises(FlyteValidationException):
         WorkflowMetadata(on_failure=0)
 
-    wm = WorkflowMetadata(on_failure=WorkflowMetadata.OnFailurePolicy.FAIL_IMMEDIATELY)
-    assert wm.on_failure == WorkflowMetadata.OnFailurePolicy.FAIL_IMMEDIATELY
+    wm = WorkflowMetadata(on_failure=WorkflowFailurePolicy.FAIL_IMMEDIATELY)
+    assert wm.on_failure == WorkflowFailurePolicy.FAIL_IMMEDIATELY
 
 
 def test_default_metadata_values():
@@ -31,7 +31,7 @@ def test_workflow_values():
         a = a + 2
         return a, "world-" + str(a)
 
-    @workflow(interruptible=True, failure_policy=WorkflowMetadata.OnFailurePolicy.FAIL_AFTER_EXECUTABLE_NODES_COMPLETE)
+    @workflow(interruptible=True, failure_policy=WorkflowFailurePolicy.FAIL_AFTER_EXECUTABLE_NODES_COMPLETE)
     def wf(a: int) -> (str, str):
         x, y = t1(a=a)
         u, v = t1(a=x)


### PR DESCRIPTION
* Add a WorkflowMetadata dataclass
* Add a WorkflowMetadataDefaults dataclass
* Hook up data classes to constuctors and expose those settings in the workflow decorator
* Remove unnecessary Workflow input to construct_input_promises
* Add a docstring to the workflow decorator.
