### PR TITLE
Create ReferenceTask from task ID

### DIFF
--- a/tests/flytekit/unit/annotated/test_references.py
+++ b/tests/flytekit/unit/annotated/test_references.py
@@ -64,10 +64,13 @@ def test_ref():
 
 def test_ref_task_more():
     @reference_task(
-        project="flytesnacks",
-        domain="development",
-        name="recipes.aaa.simple.join_strings",
-        version="553018f39e519bdb2597b652639c30ce16b99c79",
+        id=_identifier_model.Identifier(
+            _identifier_model.ResourceType.TASK,
+            "flytesnacks",
+            "development",
+            "recipes.aaa.simple.join_strings",
+            "553018f39e519bdb2597b652639c30ce16b99c79",
+        )
     )
     def ref_t1(a: typing.List[str]) -> str:
         ...


### PR DESCRIPTION
# TL;DR
Make it possible to create `ReferenceTask` from task ID directly.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
In case that the task is fetched remotely first, it is simpler just to pass in the task id.

Not super sure how much sense this makes though.

## Tracking Issue
_NA_

## Follow-up issue
_NA_
