### PR TITLE
Hide remaining implementations

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -1,20 +1,25 @@
 import flytekit.plugins  # noqa: F401
 from flytekit.annotated.base_sql_task import SQLTask
-from flytekit.annotated.base_task import TaskMetadata, kwtypes
+from flytekit.annotated.base_task import PythonTask, TaskMetadata, kwtypes
 from flytekit.annotated.condition import conditional
 from flytekit.annotated.container_task import ContainerTask
 from flytekit.annotated.context_manager import ExecutionParameters, FlyteContext
 from flytekit.annotated.dynamic_workflow_task import dynamic
+from flytekit.annotated.interface import Interface
 from flytekit.annotated.launch_plan import LaunchPlan
 from flytekit.annotated.map_task import maptask
+from flytekit.annotated.notification import Email, PagerDuty, Slack
 from flytekit.annotated.reference import get_reference_entity
 from flytekit.annotated.reference_entity import LaunchPlanReference, TaskReference, WorkflowReference
 from flytekit.annotated.resources import Resources
+from flytekit.annotated.schedule import CronSchedule, FixedRate
 from flytekit.annotated.task import reference_task, task
+from flytekit.annotated.testing import patch, task_mock
+from flytekit.annotated.type_engine import TypeEngine, TypeTransformer
 from flytekit.annotated.workflow import WorkflowFailurePolicy, reference_workflow, workflow
 from flytekit.loggers import logger
 
-__version__ = "0.16.0b2"
+__version__ = "0.16.0b3"
 
 
 def current_context() -> ExecutionParameters:

--- a/flytekit/annotated/testing.py
+++ b/flytekit/annotated/testing.py
@@ -2,10 +2,10 @@ from contextlib import contextmanager
 from typing import Union
 from unittest.mock import MagicMock
 
-from flytekit.loggers import logger
 from flytekit.annotated.base_task import PythonTask
 from flytekit.annotated.reference_entity import ReferenceEntity
 from flytekit.annotated.workflow import Workflow
+from flytekit.loggers import logger
 
 
 @contextmanager

--- a/flytekit/annotated/testing.py
+++ b/flytekit/annotated/testing.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 from typing import Union
 from unittest.mock import MagicMock
 
-from flytekit import logger
+from flytekit.loggers import logger
 from flytekit.annotated.base_task import PythonTask
 from flytekit.annotated.reference_entity import ReferenceEntity
 from flytekit.annotated.workflow import Workflow

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ extras_require = {
 
 setup(
     name="flytekit",
-    version="0.16.0b2",
+    version="0.16.0b3",
     maintainer="Lyft",
     maintainer_email="flyte-eng@lyft.com",
     packages=find_packages(exclude=["tests*"]),


### PR DESCRIPTION
# TL;DR
These were missed!  We need to put these imports at the top layer.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
I just went through the cookbook as it stands on master and looked for imports that still referred to the `annotated` folder (which we're shortly going to rename).

Some of these are only used by extensions but it's still nice to move them.

